### PR TITLE
show line numbers and show whitespace

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/UnderlyingEditorSettings.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/UnderlyingEditorSettings.java
@@ -2,4 +2,6 @@ package net.sourceforge.vrapper.platform;
 
 public interface UnderlyingEditorSettings {
     void setReplaceMode(boolean replace);
+    void setShowLineNumbers(boolean show);
+    void setShowWhitespace(boolean show);
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
@@ -11,23 +11,25 @@ import net.sourceforge.vrapper.platform.Configuration.Option;
 
 public interface Options {
     // Boolean options:
-    public static final Option<Boolean> SMART_INDENT      = bool("smartindent",     true,  "si");
-    public static final Option<Boolean> AUTO_INDENT       = bool("autoindent",      false, "ai");
-    public static final Option<Boolean> ATOMIC_INSERT     = bool("atomicinsert",    true,  "ati");
-    public static final Option<Boolean> IGNORE_CASE       = bool("ignorecase",      false, "ic");
-    public static final Option<Boolean> SMART_CASE        = bool("smartcase",       false, "scs");
-    public static final Option<Boolean> MOVE_ON_YANK      = bool("moveonyank",      true);
-    public static final Option<Boolean> SANE_CW           = bool("sanecw",          false);
-    public static final Option<Boolean> SANE_Y            = bool("saney",           false);
-    public static final Option<Boolean> SEARCH_HIGHLIGHT  = bool("hlsearch",        false, "hls");
-    public static final Option<Boolean> SEARCH_REGEX      = bool("regexsearch",     false, "rxs");
-    public static final Option<Boolean> INCREMENTAL_SEARCH = bool("incsearch",      false, "is");
+    public static final Option<Boolean> SMART_INDENT       = bool("smartindent",  true,  "si");
+    public static final Option<Boolean> AUTO_INDENT        = bool("autoindent",   false, "ai");
+    public static final Option<Boolean> ATOMIC_INSERT      = bool("atomicinsert", true,  "ati");
+    public static final Option<Boolean> IGNORE_CASE        = bool("ignorecase",   false, "ic");
+    public static final Option<Boolean> SMART_CASE         = bool("smartcase",    false, "scs");
+    public static final Option<Boolean> MOVE_ON_YANK       = bool("moveonyank",   true);
+    public static final Option<Boolean> SANE_CW            = bool("sanecw",       false);
+    public static final Option<Boolean> SANE_Y             = bool("saney",        false);
+    public static final Option<Boolean> SEARCH_HIGHLIGHT   = bool("hlsearch",     false, "hls");
+    public static final Option<Boolean> SEARCH_REGEX       = bool("regexsearch",  false, "rxs");
+    public static final Option<Boolean> INCREMENTAL_SEARCH = bool("incsearch",    false, "is");
+    public static final Option<Boolean> LINE_NUMBERS       = bool("number",       false, "nu");
+    public static final Option<Boolean> SHOW_WHITESPACE    = bool("list",         false, "l");
 
     @SuppressWarnings("unchecked")
     public static final Set<Option<Boolean>> BOOLEAN_OPTIONS = set(
             SMART_INDENT, AUTO_INDENT, ATOMIC_INSERT, IGNORE_CASE, SMART_CASE,
             MOVE_ON_YANK, SANE_CW, SANE_Y, SEARCH_HIGHLIGHT, SEARCH_REGEX,
-            INCREMENTAL_SEARCH);
+            INCREMENTAL_SEARCH, LINE_NUMBERS, SHOW_WHITESPACE);
 
     // String options:
     public static final Option<String> SELECTION = string("selection", "inclusive", "old, inclusive, exclusive", "sel");

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
@@ -142,6 +142,8 @@ public class CommandLineParser extends AbstractCommandParser {
         }
         // overwrites hlsearch/nohlsearch commands
         Evaluator hlsToggle = new OptionDependentEvaluator(Options.SEARCH_HIGHLIGHT, ConfigAction.NO_HL_SEARCH, ConfigAction.HL_SEARCH);
+        Evaluator numberToggle = new OptionDependentEvaluator(Options.LINE_NUMBERS, ConfigAction.NO_LINE_NUMBERS, ConfigAction.LINE_NUMBERS);
+        Evaluator listToggle = new OptionDependentEvaluator(Options.SHOW_WHITESPACE, ConfigAction.NO_SHOW_WHITESPACE, ConfigAction.SHOW_WHITESPACE);
         config.add("hlsearch", ConfigAction.HL_SEARCH);
         config.add("nohlsearch", ConfigAction.NO_HL_SEARCH);
         config.add("hls", ConfigAction.HL_SEARCH);
@@ -152,6 +154,15 @@ public class CommandLineParser extends AbstractCommandParser {
         config.add("noglobalregisters", ConfigAction.NO_GLOBAL_REGISTERS);
         config.add("localregisters", ConfigAction.NO_GLOBAL_REGISTERS);
         config.add("nolocalregisters", ConfigAction.GLOBAL_REGISTERS);
+        config.add("number", ConfigAction.LINE_NUMBERS);
+        config.add("nonumber", ConfigAction.NO_LINE_NUMBERS);
+        config.add("nu", ConfigAction.LINE_NUMBERS);
+        config.add("nonu", ConfigAction.NO_LINE_NUMBERS);
+        config.add("number!", numberToggle);
+        config.add("nu!", numberToggle);
+        config.add("list", ConfigAction.SHOW_WHITESPACE);
+        config.add("nolist", ConfigAction.NO_SHOW_WHITESPACE);
+        config.add("list!", listToggle);
 
         return config;
     }
@@ -222,6 +233,34 @@ public class CommandLineParser extends AbstractCommandParser {
             public Object evaluate(EditorAdaptor vim, Queue<String> command) {
                 vim.getConfiguration().set(Options.SEARCH_HIGHLIGHT, Boolean.FALSE);
                 vim.getSearchAndReplaceService().removeHighlighting();
+                return null;
+            }
+        },
+        LINE_NUMBERS {
+            public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+                vim.getConfiguration().set(Options.LINE_NUMBERS, Boolean.TRUE);
+                vim.getEditorSettings().setShowLineNumbers(true);
+                return null;
+            }
+        },
+        NO_LINE_NUMBERS {
+            public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+                vim.getConfiguration().set(Options.LINE_NUMBERS, Boolean.FALSE);
+                vim.getEditorSettings().setShowLineNumbers(false);
+                return null;
+            }
+        },
+        SHOW_WHITESPACE {
+            public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+                vim.getConfiguration().set(Options.SHOW_WHITESPACE, Boolean.TRUE);
+                vim.getEditorSettings().setShowWhitespace(true);
+                return null;
+            }
+        },
+        NO_SHOW_WHITESPACE {
+            public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+                vim.getConfiguration().set(Options.SHOW_WHITESPACE, Boolean.FALSE);
+                vim.getEditorSettings().setShowWhitespace(false);
                 return null;
             }
         }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/AbstractTextEditorSettings.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/AbstractTextEditorSettings.java
@@ -5,6 +5,8 @@ import java.lang.reflect.Method;
 import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.platform.UnderlyingEditorSettings;
 
+import org.eclipse.ui.editors.text.EditorsUI;
+import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 
 public class AbstractTextEditorSettings implements UnderlyingEditorSettings {
@@ -29,6 +31,14 @@ public class AbstractTextEditorSettings implements UnderlyingEditorSettings {
         } catch (Exception exception) {
             VrapperLog.error("error when enabling replace mode", exception);
         }
+    }
+    
+    public void setShowLineNumbers(boolean show) {
+        EditorsUI.getPreferenceStore().setValue(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_LINE_NUMBER_RULER, show);
+    }
+    
+    public void setShowWhitespace(boolean show) {
+        EditorsUI.getPreferenceStore().setValue(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SHOW_WHITESPACE_CHARACTERS , show);
     }
 
 }


### PR DESCRIPTION
This commit implements the features requested in the following tickets of vrapper's trac page:
#85     set number/set nonumber
#86     set list/set nolist

I've implemented ':set number', ':set nonumber', ':set number!', ':set nu', ':set nonu', ':set nu!' for the show line numbers and ':set list', ':set nolist', ':set list!' for the show whitespace.  This is consistent with vim's options.  I tried to follow the conventions used for the hlsearch/nohlsearch feature so hopefully this works for you guys.
