### PR TITLE
Fix for c2w defect

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveLeftWithBounds.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveLeftWithBounds.java
@@ -11,7 +11,7 @@ public abstract class MoveLeftWithBounds extends MoveWithBounds {
     }
 
     @Override
-	protected int destination(int offset, TextContent content, boolean bailOff) {
+	protected int destination(int offset, TextContent content, boolean bailOff, boolean hasMoreCounts) {
 		boolean haveMoved = false;
 		// special case - end of buffer
 		final int last = content.getTextLength() - 1;

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveRightWithBounds.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveRightWithBounds.java
@@ -10,7 +10,7 @@ public abstract class MoveRightWithBounds extends MoveWithBounds {
     }
 
     @Override
-	protected int destination(int offset, TextContent content, boolean bailOff) {
+	protected int destination(int offset, TextContent content, boolean bailOff, boolean hasMoreCounts) {
 		// ensure we don't stay inside object
 		if (!bailOff && shouldStopAtLeftBoundingChar())
 			++offset;
@@ -27,7 +27,7 @@ public abstract class MoveRightWithBounds extends MoveWithBounds {
 			}
 		}
 
-		if (!shouldStopAtLeftBoundingChar())
+		if (!shouldStopAtLeftBoundingChar() || hasMoreCounts)
 			++offset;
 
 		return min(offset, textLen);

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveWithBounds.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveWithBounds.java
@@ -10,7 +10,7 @@ public abstract class MoveWithBounds extends CountAwareMotion {
     protected abstract boolean atBoundary(char c1, char c2);
     protected abstract boolean stopsAtNewlines();
     protected abstract boolean shouldStopAtLeftBoundingChar();
-    protected abstract int destination(int offset, TextContent viewContent, boolean bailOff);
+    protected abstract int destination(int offset, TextContent viewContent, boolean bailOff, boolean hasMoreCounts);
 
     private final boolean bailOff;
     
@@ -30,7 +30,7 @@ public abstract class MoveWithBounds extends CountAwareMotion {
         int offset = editorAdaptor.getPosition().getModelOffset();
 
         for (int i = 0; i < count; i++)
-            offset = destination(offset, editorAdaptor.getModelContent(), bailOff && i == 0);
+            offset = destination(offset, editorAdaptor.getModelContent(), bailOff && i == 0, i != count-1);
         
         return editorAdaptor.getCursorService().newPositionForModelOffset(offset);
     }


### PR DESCRIPTION
My fix for 'cw' on a single character word broke the behavior for 'c2w'.  There are now unit tests for both the 'cw on single character word' and 'c2w' features.  With this commit, all unit tests pass.  It looks good to me, but I'm submitting this as a Pull Request in case someone has a cleaner solution.

Change operations typically stop at the end of a word.  This is determined by the shouldStopAtLeftBoundingChar method.  However, if we are performing a change operation with counts, we only want to stop at the left bounding char of the _last_ word.  Otherwise, stopping at the first word's left bounding char will count the next whitespace character as a word rather than jumping to the beginning of the next actual word.  I made a quick and dirty change such that if there are more count operations to come, don't ever stop at the left bounding char.

The one thing I don't like about this fix is that modifying MoveWithBounds required me to update the method arguments for MoveLeftWithBounds even though that class works just fine.  If no one has any problems with that, I'll probably just accept this Pull Request as is.
