### PR TITLE
Join without space when next line starts with ')'

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/JoinLinesCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/JoinLinesCommand.java
@@ -51,6 +51,8 @@ public class JoinLinesCommand extends CountAwareCommand {
                     glue = "";
                 for (int j = 0; j < secondLine.length() && Character.isWhitespace(secondLine.charAt(j)); j++)
                     bolOffset++;
+                if (modelContent.getText(bolOffset, 1).charAt(0) == ')')
+                    glue = "";
             } else
                 glue = "";
             modelContent.replace(eolOffset, bolOffset - eolOffset, glue);


### PR DESCRIPTION
In Vim, the join command does not insert white space when the next line
of a join starts with a ')'.
