### PR TITLE
Adding unnamed clipboard support

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
@@ -34,9 +34,10 @@ public interface Options {
             VISUAL_MOUSE);
 
     // String options:
+    public static final Option<String> CLIPBOARD = string("clipboard", "autoselect", "unnamed, autoselect", "cb");
     public static final Option<String> SELECTION = string("selection", "inclusive", "old, inclusive, exclusive", "sel");
     @SuppressWarnings("unchecked")
-    public static final Set<Option<String>> STRING_OPTIONS = set(SELECTION);
+    public static final Set<Option<String>> STRING_OPTIONS = set(CLIPBOARD, SELECTION);
 
     // Int options:
     public static final Option<Integer> SCROLL_OFFSET = integer("scrolloff",  0, "so");

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
@@ -4,6 +4,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.StringTokenizer;
 
+import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.platform.Configuration.Option;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.utils.Search;
@@ -32,6 +33,8 @@ import net.sourceforge.vrapper.vim.modes.AbstractVisualMode;
 import net.sourceforge.vrapper.vim.modes.InsertMode;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
 import net.sourceforge.vrapper.vim.modes.VisualMode;
+import net.sourceforge.vrapper.vim.register.Register;
+import net.sourceforge.vrapper.vim.register.RegisterManager;
 
 /**
  * Command Line Mode, activated with ':'.
@@ -162,6 +165,8 @@ public class CommandLineParser extends AbstractCommandParser {
         config.add("noglobalregisters", ConfigAction.NO_GLOBAL_REGISTERS);
         config.add("localregisters", ConfigAction.NO_GLOBAL_REGISTERS);
         config.add("nolocalregisters", ConfigAction.GLOBAL_REGISTERS);
+        config.add("clipboard", ConfigAction.CLIPBOARD);
+        VrapperLog.info("adding clipboard action");
         config.add("number", ConfigAction.LINE_NUMBERS);
         config.add("nonumber", ConfigAction.NO_LINE_NUMBERS);
         config.add("nu", ConfigAction.LINE_NUMBERS);
@@ -264,6 +269,17 @@ public class CommandLineParser extends AbstractCommandParser {
     
     private enum ConfigAction implements Evaluator {
 
+        CLIPBOARD {
+            public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+                VrapperLog.info("clipboard used" + command);
+                if (command.contains("unnamed")) {
+                    Register clipboardRegister = vim.getRegisterManager() .getRegister(RegisterManager.REGISTER_NAME_CLIPBOARD);
+                    vim.getRegisterManager().setDefaultRegister(clipboardRegister);
+                }
+
+                return null;
+            }
+        },
         GLOBAL_REGISTERS {
             public Object evaluate(EditorAdaptor vim, Queue<String> command) {
                 vim.useGlobalRegisters();

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/AWTClipboardRegister.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/AWTClipboardRegister.java
@@ -6,6 +6,7 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 
 import net.sourceforge.vrapper.utils.ContentType;
+import net.sourceforge.vrapper.utils.VimUtils;
 import net.sourceforge.vrapper.vim.VimConstants;
 
 // XXX: we're mixing SWT with AWT here
@@ -19,10 +20,9 @@ public class AWTClipboardRegister implements Register {
             String s;
             try {
                 s = (String) c.getContents(df).getTransferData(df);
-                if (s.endsWith(VimConstants.REGISTER_NEWLINE)
-                        || s.startsWith(VimConstants.REGISTER_NEWLINE)) {
-                    return new StringRegisterContent(ContentType.LINES, s.trim()+VimConstants.REGISTER_NEWLINE);
-                }
+				if (s.endsWith(VimConstants.REGISTER_NEWLINE) || s.startsWith(VimConstants.REGISTER_NEWLINE)) {
+					return new StringRegisterContent(ContentType.LINES, s);
+				}
                 return new StringRegisterContent(ContentType.TEXT, s);
             } catch (Exception e) {
                 e.printStackTrace();
@@ -47,9 +47,6 @@ public class AWTClipboardRegister implements Register {
     public void setContent(RegisterContent content) {
         Clipboard c = Toolkit.getDefaultToolkit().getSystemClipboard();
         String s = content.getText();
-        if (content.getPayloadType() == ContentType.LINES) {
-            s += VimConstants.REGISTER_NEWLINE;
-        }
         c.setContents(new StringSelection(s), null);
     }
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
@@ -21,7 +21,7 @@ public class DefaultRegisterManager implements RegisterManager {
 
     protected final Map<String, Register> registers;
     private Register activeRegister;
-    private final Register defaultRegister;
+    private Register defaultRegister;
     private final Register lastEditRegister;
     private Search search;
     private Command lastEdit, lastInsertion;
@@ -93,6 +93,10 @@ public class DefaultRegisterManager implements RegisterManager {
 
     public Register getDefaultRegister() {
         return defaultRegister;
+    }
+
+    public void setDefaultRegister(Register register) {
+        this.defaultRegister = register;
     }
 
     public Register getActiveRegister() {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
@@ -19,6 +19,7 @@ public interface RegisterManager {
     public static final String REGISTER_NAME_SEARCH = "/";
     public static final String REGISTER_NAME_BLACKHOLE = "_";
     public static final String REGISTER_NAME_LAST = "@";
+
     Register getRegister(String name);
     Register getDefaultRegister();
     Register getActiveRegister();
@@ -41,4 +42,5 @@ public interface RegisterManager {
     boolean isDefaultRegisterActive();
 	void setLastActiveSelection(PositionlessSelection instance);
 	PositionlessSelection getLastActiveSelection();
+    public abstract void setDefaultRegister(Register register);
 }


### PR DESCRIPTION
Changing AWTClipboardRegister so that it stops trimming lines.
Before this change when using the AWTClipboardRegister as the default register,
and you yy'ed a line and pasted it, the leading whitespace would be removed. Also
fixed AWTClipboardRegister so that when payload type is lines it does not add an
extra newline to the end which would have doubled up the endin newline when using it as a
clipboard to copy and paste lines.  Adjusted CommandLineParser so that setting
'set clipboard unnamed' in the .vrapperrc file will allow you to use the system
clipboard to copy and paste to and from.
