### PR TITLE
add a CaretListener that updates the sticky column when using the mouse

### DIFF
--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
@@ -51,9 +51,9 @@ public class EclipsePlatform implements Platform {
             ITextViewer textViewer, Configuration sharedConfiguration) {
         underlyingEditor = abstractTextEditor;
         configuration = sharedConfiguration;
-        cursorAndSelection = new EclipseCursorAndSelection(configuration,
-                textViewer);
         textContent = new EclipseTextContent(textViewer);
+        cursorAndSelection = new EclipseCursorAndSelection(configuration,
+                textViewer, textContent);
         fileService = new EclipseFileService(abstractTextEditor);
         viewportService = new EclipseViewportService(textViewer);
         serviceProvider = new EclipseServiceProvider(abstractTextEditor);


### PR DESCRIPTION
Fixes the sticky column problem when using the mouse to navigate.
Updates the sticky column position and, if the user clicks to the far right of the line, sticks to EOL.
