### PR TITLE
Adding unnamed clipboard support

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -27,6 +27,7 @@ import net.sourceforge.vrapper.platform.TextContent;
 import net.sourceforge.vrapper.platform.UnderlyingEditorSettings;
 import net.sourceforge.vrapper.platform.UserInterfaceService;
 import net.sourceforge.vrapper.platform.ViewportService;
+import net.sourceforge.vrapper.platform.Configuration.Option;
 import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.utils.PositionlessSelection;
@@ -45,6 +46,7 @@ import net.sourceforge.vrapper.vim.modes.commandline.CommandLineParser;
 import net.sourceforge.vrapper.vim.modes.commandline.PasteRegisterMode;
 import net.sourceforge.vrapper.vim.modes.commandline.SearchMode;
 import net.sourceforge.vrapper.vim.register.DefaultRegisterManager;
+import net.sourceforge.vrapper.vim.register.Register;
 import net.sourceforge.vrapper.vim.register.RegisterManager;
 
 public class DefaultEditorAdaptor implements EditorAdaptor {
@@ -88,6 +90,22 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
         this.serviceProvider = editor.getServiceProvider();
         this.editorSettings = editor.getUnderlyingEditorSettings();
         this.configuration = new SimpleLocalConfiguration(editor.getConfiguration());
+        LocalConfigurationListener listener = new LocalConfigurationListener() {
+            
+            public <T> void optionChanged(Option<T> option, T oldValue, T newValue) {
+                if("clipboard".equals(option.getId())) {
+                    if("unnamed".equals(newValue)) {
+                        Register clipboardRegister = DefaultEditorAdaptor.this.getRegisterManager().getRegister(RegisterManager.REGISTER_NAME_CLIPBOARD);
+                        DefaultEditorAdaptor.this.getRegisterManager().setDefaultRegister(clipboardRegister);
+                    } else {
+                        Register unnamedRegister = DefaultEditorAdaptor.this.getRegisterManager().getRegister(RegisterManager.REGISTER_NAME_UNNAMED);
+                        DefaultEditorAdaptor.this.getRegisterManager().setDefaultRegister(unnamedRegister);
+                    }
+                }
+                
+            }
+        };
+        this.configuration.addListener(listener);
         this.platformSpecificStateProvider = editor.getPlatformSpecificStateProvider();
         this.searchAndReplaceService = editor.getSearchAndReplaceService();
         viewportService = editor.getViewportService();

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
@@ -34,9 +34,10 @@ public interface Options {
             VISUAL_MOUSE);
 
     // String options:
+    public static final Option<String> CLIPBOARD = string("clipboard", "autoselect", "unnamed, autoselect", "cb");
     public static final Option<String> SELECTION = string("selection", "inclusive", "old, inclusive, exclusive", "sel");
     @SuppressWarnings("unchecked")
-    public static final Set<Option<String>> STRING_OPTIONS = set(SELECTION);
+    public static final Set<Option<String>> STRING_OPTIONS = set(CLIPBOARD, SELECTION);
 
     // Int options:
     public static final Option<Integer> SCROLL_OFFSET = integer("scrolloff",  0, "so");

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
@@ -4,6 +4,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.StringTokenizer;
 
+import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.platform.Configuration.Option;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.utils.Search;
@@ -32,6 +33,8 @@ import net.sourceforge.vrapper.vim.modes.AbstractVisualMode;
 import net.sourceforge.vrapper.vim.modes.InsertMode;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
 import net.sourceforge.vrapper.vim.modes.VisualMode;
+import net.sourceforge.vrapper.vim.register.Register;
+import net.sourceforge.vrapper.vim.register.RegisterManager;
 
 /**
  * Command Line Mode, activated with ':'.

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
@@ -21,7 +21,7 @@ public class DefaultRegisterManager implements RegisterManager {
 
     protected final Map<String, Register> registers;
     private Register activeRegister;
-    private final Register defaultRegister;
+    private Register defaultRegister;
     private final Register lastEditRegister;
     private Search search;
     private Command lastEdit, lastInsertion;
@@ -91,6 +91,10 @@ public class DefaultRegisterManager implements RegisterManager {
 
     public Register getDefaultRegister() {
         return defaultRegister;
+    }
+
+    public void setDefaultRegister(Register register) {
+        this.defaultRegister = register;
     }
 
     public Register getActiveRegister() {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
@@ -19,6 +19,7 @@ public interface RegisterManager {
     public static final String REGISTER_NAME_SEARCH = "/";
     public static final String REGISTER_NAME_BLACKHOLE = "_";
     public static final String REGISTER_NAME_LAST = "@";
+
     Register getRegister(String name);
     Register getDefaultRegister();
     Register getActiveRegister();
@@ -41,4 +42,5 @@ public interface RegisterManager {
     boolean isDefaultRegisterActive();
 	void setLastActiveSelection(PositionlessSelection instance);
 	PositionlessSelection getLastActiveSelection();
+    public abstract void setDefaultRegister(Register register);
 }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/SWTClipboardRegister.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/SWTClipboardRegister.java
@@ -35,7 +35,7 @@ public class SWTClipboardRegister implements Register {
     public void setContent(RegisterContent content) {
         String s = content.getText();
         if (content.getPayloadType() == ContentType.LINES) {
-            s += VimConstants.REGISTER_NEWLINE;
+            s = normalizeLineBreaks(s);
         }
         clipboard.setContents(new Object[] { s }, new Transfer[] { TextTransfer.getInstance() });
     }


### PR DESCRIPTION
Changing SWTClipboardRegister so that it stops adding a extra newline to
the system clipboard.  Before this change when using the SWTClipboardRegister
as the default register, and you yy'ed a line and pasted it to another application,
an extra newline would be added to the end.  Adjusted CommandLineParser and added
a configuration listener so that setting 'set clipboard=unnamed' in the .vrapperrc
file will allow you to use the system clipboard to copy and paste to and from.

The listener implementation I used isn't the prettiest as it puts code in the DefaultEditorAdaptor instead of the CommandLineParser, but I couldn't find a cleaner way add the "=" sign that fit within the current way things were structured.
