### PR TITLE
Do not share NewLine value between editor's instances

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/SimpleLocalConfiguration.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/SimpleLocalConfiguration.java
@@ -8,24 +8,29 @@ import net.sourceforge.vrapper.platform.SimpleConfiguration.NewLine;
 
 /** Wraps a {@link Configuration}, allowing to notify {@link LocalConfigurationListener}. */
 public class SimpleLocalConfiguration implements LocalConfiguration {
+    
     protected Configuration sharedConfiguration;
+    
+    protected String newLine;
+    
     protected List<LocalConfigurationListener> listeners =
             new CopyOnWriteArrayList<LocalConfigurationListener>();
 
     public SimpleLocalConfiguration(Configuration configuration) {
         sharedConfiguration = configuration;
+        newLine = sharedConfiguration.getNewLine();
     }
 
     public String getNewLine() {
-        return sharedConfiguration.getNewLine();
+        return newLine;
     }
 
     public void setNewLine(String newLine) {
-        sharedConfiguration.setNewLine(newLine);
+        this.newLine = newLine;
     }
 
     public void setNewLine(NewLine newLine) {
-        sharedConfiguration.setNewLine(newLine);
+        this.newLine = newLine.nl;
     }
 
     public <T> void set(Option<T> key, T value) {


### PR DESCRIPTION
At the end I found the root of issue with inconsistent EOL. Currently, we are sharing newLine value between editors, so I fixed `SimpleLocalConfiguration` for keeping local newLine value. It's easy to reproduce:
1. Open Unix-style eol file.
2. Open Windows-style eol file.
3. Switch to Unix-style eol file back.
4. Hit `o` key for new line, `ESC` and `:w` to save file.
5. Check file content with hex-editor.
