### PR TITLE
Refactoring length() in LineInformation to regionLength() + fixed 2 exception

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/LineInformation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/LineInformation.java
@@ -11,12 +11,16 @@ public class LineInformation {
     private final int number;
     private final int beginOffset;
     private final int length;
+    private final int regionLength;
+    private final boolean isBlankLine;
 
-    public LineInformation(int number, int beginOffset, int length) {
+    public LineInformation(int number, int beginOffset, int length, int regionLength, boolean isBlankLine) {
         super();
         this.number = number;
         this.beginOffset = beginOffset;
         this.length = length;
+        this.regionLength = regionLength;
+        this.isBlankLine = isBlankLine;
     }
 
     /**
@@ -33,13 +37,36 @@ public class LineInformation {
     public int getBeginOffset() {
         return beginOffset;
     }
+    
+    /**
+     * Returns the length of the line excluding delimiter 
+     */
+    public int getRegionLength() {
+        return regionLength;
+    }
 
+    /**
+     * Returns the last offset on the line including delimiter
+     */
+    public int getEndOffset() {
+        return beginOffset+length-1;
+    }
+    
+    /**
+     * Returns the length of the whole line including delimiter 
+     */
     public int getLength() {
         return length;
     }
 
-    public int getEndOffset() {
-        return beginOffset+length;
+    public boolean isEmpty() {
+        return getLength() == 0;
     }
 
+    /**
+     * Blank lines have length == 1 and contain only newline character  
+     */
+    public boolean isBlankLine() {
+        return isBlankLine;
+    }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/ExCommandOperation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/ExCommandOperation.java
@@ -163,7 +163,7 @@ public class ExCommandOperation extends SimpleTextOperation {
 	private boolean processLine(String pattern, boolean findMatch, SimpleTextOperation operation,
 			LineInformation line, EditorAdaptor editorAdaptor) {
 		boolean operationPerformed = false;
-		String text = editorAdaptor.getModelContent().getText(line.getBeginOffset(), line.getLength());
+		String text = editorAdaptor.getModelContent().getText(line.getBeginOffset(), line.getRegionLength());
 		//Java's matches() method expects to match the entire string.
 		//If the user isn't explicitly matching beginning or end of
 		//a String, fake it out so Java is happy.

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/IncrementDecrementCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/IncrementDecrementCommand.java
@@ -45,7 +45,7 @@ public class IncrementDecrementCommand extends CountAwareCommand {
 		TextContent content = editorAdaptor.getModelContent(); 
 	 	LineInformation line = content.getLineInformationOfOffset(cursor.getModelOffset()); 
 	 	int cursorIndex = cursor.getModelOffset() - line.getBeginOffset();
-	 	String text = content.getText(line.getBeginOffset(), line.getLength()); 
+	 	String text = content.getText(line.getBeginOffset(), line.getRegionLength()); 
 	 	NumBoundary boundary = null;
 	 	
 	 	//Look for both hex and integers (decimal and octal).

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/JoinLinesCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/JoinLinesCommand.java
@@ -53,12 +53,12 @@ public class JoinLinesCommand extends CountAwareCommand {
             LineInformation secondLnInfo = modelContent.getLineInformation(firstLnInfo.getNumber() + 1);
             int eolOffset = firstLnInfo.getEndOffset();
             int bolOffset = secondLnInfo.getBeginOffset();
-            String secondLineText = modelContent.getText(bolOffset, secondLnInfo.getLength());
+            String secondLineText = modelContent.getText(bolOffset, secondLnInfo.getRegionLength());
             LineInformation lastLineInfo = modelContent.getLineInformation(modelContent.getNumberOfLines() - 1);
             String glue;
             if (isSmart) {
                 glue = " ";
-                if (firstLnInfo.getLength() > 0 && Character.isWhitespace(modelContent.getText(eolOffset - 1, 1).charAt(0)))
+                if (firstLnInfo.getRegionLength() > 0 && Character.isWhitespace(modelContent.getText(eolOffset - 1, 1).charAt(0)))
                     glue = "";
                 for (int j = 0; j < secondLineText.length() && Character.isWhitespace(secondLineText.charAt(j)); j++)
                     bolOffset++;

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SortOperation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SortOperation.java
@@ -290,7 +290,7 @@ public class SortOperation extends SimpleTextOperation {
          */
         for(int i = startLine.getNumber(); i <= endLine.getNumber(); ++i) {
             line = content.getLineInformation(i);
-            String lineStr = content.getText(line.getBeginOffset(), line.getLength());
+            String lineStr = content.getText(line.getBeginOffset(), line.getRegionLength());
             editorContentList.add(lineStr);
         }
        

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ParagraphMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ParagraphMotion.java
@@ -47,6 +47,13 @@ public class ParagraphMotion extends CountAwareMotion {
         }
         
         lineNo = moveMore(modelContent, lineNo);
+        if (lineNo < 0) {
+            lineNo = 0;
+        }
+        else if (lineNo >= modelContent.getNumberOfLines()){
+            lineNo = modelContent.getNumberOfLines() - 1;
+        }
+        
         int offset = modelContent.getLineInformation(lineNo).getBeginOffset();
         return editorAdaptor.getPosition().setModelOffset(offset);
     }
@@ -65,8 +72,13 @@ public class ParagraphMotion extends CountAwareMotion {
     
     private boolean doesLineEmptinessEqual(boolean equalWhat, TextContent content, int lineNo) {
         boolean isInRange = (lineNo + step >= 0) && (lineNo + step <= content.getNumberOfLines());
-        boolean isEmpty = content.getLineInformation(lineNo).getLength() == 0;
-        return isInRange && (isEmpty == equalWhat);
+        if (!isInRange) {
+            return false;
+        }
+        
+        LineInformation lineInfo = content.getLineInformation(lineNo);
+        boolean isEmpty = lineInfo.isEmpty() || lineInfo.isBlankLine();
+        return isEmpty == equalWhat;
     }
 
     public BorderPolicy borderPolicy() {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/SentenceMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/SentenceMotion.java
@@ -62,20 +62,20 @@ public class SentenceMotion extends CountAwareMotion {
         
         while(offset == -1) {
         	if(forward) {
-        		if(modelContent.getNumberOfLines() > line.getNumber()) {
+        		if(modelContent.getNumberOfLines() > (line.getNumber() + 1)) {
         			lineTmp = line;
         			//get next line, starting at beginning of line
         			line = modelContent.getLineInformation(line.getNumber() + 1);
         			position = line.getBeginOffset();
         			//empty lines are sentence boundaries too
-        			if(line.getLength() == 0 && lineTmp.getLength() != 0 ||
-        				line.getLength() != 0 && lineTmp.getLength() == 0) {
+        			if(line.getRegionLength() == 0 && lineTmp.getRegionLength() != 0 ||
+        				line.getRegionLength() != 0 && lineTmp.getRegionLength() == 0) {
         				return line.getBeginOffset();
         			}
         		}
         		else {
         			//already on last line in file, move cursor to the end
-        			return line.getEndOffset();
+        			return line.isEmpty() ? line.getBeginOffset() : line.getEndOffset();
         		}
         	}
         	else { //backwards
@@ -86,8 +86,8 @@ public class SentenceMotion extends CountAwareMotion {
         			line = modelContent.getLineInformation(line.getNumber() - 1);
         			position = line.getEndOffset();
         			//empty lines are sentence boundaries too
-        			if(line.getLength() == 0 && lineTmp.getLength() != 0 ||
-        				line.getLength() != 0 && lineTmp.getLength() == 0) {
+        			if(line.getRegionLength() == 0 && lineTmp.getRegionLength() != 0 ||
+        				line.getRegionLength() != 0 && lineTmp.getRegionLength() == 0) {
         				//if posTmp was already at the beginning of this line, go to previous line
         				//otherwise, go to beginning of this line
         				return posTmp == lineTmp.getBeginOffset() ? line.getBeginOffset() : lineTmp.getBeginOffset();
@@ -110,7 +110,7 @@ public class SentenceMotion extends CountAwareMotion {
         int begin = line.getBeginOffset();
         String text;
         if(forward) {
-        	int length = line.getLength() - (position - begin);
+        	int length = line.getRegionLength() - (position - begin);
         	//start at cursor, get text to end of line
         	text = modelContent.getText(position, length);
         }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/NormalMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/NormalMode.java
@@ -356,7 +356,7 @@ public class NormalMode extends CommandBasedMode {
         Position pos = editorAdaptor.getPosition();
         int offset = pos.getViewOffset();
         LineInformation line = editorAdaptor.getViewContent().getLineInformationOfOffset(offset);
-        if (isEnabled && line.getEndOffset() == offset && line.getLength() > 0) {
+        if (isEnabled && line.getEndOffset() == offset && line.getRegionLength() > 0) {
             editorAdaptor.setPosition(pos.addViewOffset(-1), false);
         }
     }


### PR DESCRIPTION
getLength() in LineInformation returning only part of the line wasn't very intuitive, so now it returns the length of the whole line with delimiter. I kept the old functionality in method getRegionLength() for backward compatibility.
The method getEndOffset() now returns the last position in the line (including delimiter). This is mostly backward compatible, the only difference is that the old method could return offset outside of the editor range if we were querying information about the last line.
I also fixed two exceptions, which were thrown on ParagraphMotion and SentenceMotion if we were on the last line.
