### PR TITLE
Fixed line joining

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
@@ -815,13 +815,19 @@ public class NormalModeTests extends CommandTestCase {
                 "sth   ",'s',"th");
         checkCommand(forKeySeq("2J"),
                 "s",'t',"h\nsth\nsth",
-                "sth sth",' ',"sth");
+                "sth", ' ', "sth\nsth");
         checkCommand(forKeySeq("J"),
                 "s",'t',"h\n   sth",
                 "sth",' ',"sth");
         checkCommand(forKeySeq("JJ"),
                 "s",'t',"h\n\nsth",
                 "sth ",'s',"th");
+        checkCommand(forKeySeq("J"),
+                "",'\n',"hello",
+                "",'h',"ello");
+        checkCommand(forKeySeq("3J"),
+                "th",'i',"s\njoins\nthree lines",
+                "this joins",' ',"three lines");
     }
 
 	@Test
@@ -831,7 +837,7 @@ public class NormalModeTests extends CommandTestCase {
                 "sth",'s',"th");
         checkCommand(forKeySeq("2gJ"),
                 "s",'t',"h\nsth\nsth",
-                "sthsth",'s',"th");
+                "sth",'s',"th\nsth");
         checkCommand(forKeySeq("gJ"),
                 "s",'t',"h\n   sth",
                 "sth",' ',"  sth");

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VisualModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VisualModeTests.java
@@ -274,6 +274,9 @@ public class VisualModeTests extends CommandTestCase {
 		checkLeavingCommand(forKeySeq("gJ"),
 				false,  "new Hell","o\nW","orld();\n//;-)",
 				"new Hello",'W',"orld();\n//;-)");
+		checkLeavingCommand(forKeySeq("J"),
+				false,  "","\n\nh","ello",
+				"",'h',"ello");
     }
 	
 	@Test

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/JoinVisualLinesCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/JoinVisualLinesCommand.java
@@ -1,6 +1,7 @@
 package net.sourceforge.vrapper.vim.commands;
 
 import net.sourceforge.vrapper.platform.TextContent;
+import net.sourceforge.vrapper.utils.ContentType;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
@@ -27,7 +28,13 @@ public class JoinVisualLinesCommand extends AbstractCommand {
             editorAdaptor.getHistory().beginCompoundChange();
             editorAdaptor.changeMode(NormalMode.NAME);
             editorAdaptor.setPosition(from, false);
-            JoinLinesCommand.doIt(editorAdaptor, lastLineNo - firstLineNo, isSmart);
+            
+            int length = 1 + lastLineNo - firstLineNo;
+            if (ContentType.LINES.equals(selection.getContentType(editorAdaptor.getConfiguration()))) {
+                length--;
+            }
+            
+            JoinLinesCommand.doIt(editorAdaptor, Math.max(2, length), isSmart);
         } finally {
             editorAdaptor.getHistory().endCompoundChange();
         }


### PR DESCRIPTION
(1) If more than one line (lets say n) was selected in linewise selection, then n+1 lines were joined. Now we join only n lines.

(2) If the cursor was on line containing only newline and we joined it with another line, then those lines were glued with space. Experiments in Vim show that the space is not added in this case (although this behavior is not documented in manual), therefore we are omitting it now. I added a unit test for this case.

(3) When count was specified, it joined count+1 lines. According to the Vim manual, exactly count number of lines must be joined with minimal number of 2 lines. I also changed two unit tests to consider this behavior.
