### PR TITLE
Fixed stationary cursor in linewise visual mode

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/StartEndTextRange.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/StartEndTextRange.java
@@ -51,22 +51,37 @@ public class StartEndTextRange implements TextRange {
         TextContent txt = editor.getModelContent();
         LineInformation sLine = txt.getLineInformationOfOffset(from.getModelOffset());
         LineInformation eLine = txt.getLineInformationOfOffset(to.getModelOffset());
-        if (sLine.getNumber() > eLine.getNumber())
-            return lines(editor, to, from);
+        
         CursorService cs = editor.getCursorService();
-        int startIndex = sLine.getBeginOffset();
-        int nextLineNo = eLine.getNumber() + 1;
-        int endIndex;
-        if (nextLineNo < txt.getNumberOfLines())
-            endIndex = txt.getLineInformation(nextLineNo).getBeginOffset();
-        else {
-            endIndex = txt.getTextLength();
-            if (sLine.getNumber() == 0)
-                startIndex = 0;
+        int firstLine, nextLineTolastLine;
+        if (sLine.getNumber() > eLine.getNumber()) {
+            firstLine = eLine.getNumber();
+            nextLineTolastLine = sLine.getNumber() + 1;
         }
-        return new StartEndTextRange(
-                cs.newPositionForModelOffset(startIndex),
-                cs.newPositionForModelOffset(endIndex));
+        else {
+            firstLine = sLine.getNumber();
+            nextLineTolastLine = eLine.getNumber() + 1;
+        }
+        
+        int beginOffset = txt.getLineInformation(firstLine).getBeginOffset(), endOffset;
+        if (nextLineTolastLine < txt.getNumberOfLines())
+            endOffset = txt.getLineInformation(nextLineTolastLine).getBeginOffset();
+        else {
+            endOffset = txt.getTextLength();
+            if (firstLine == 0)
+                beginOffset = 0;
+        }
+        
+        if (sLine.getNumber() > eLine.getNumber()) {
+            return new StartEndTextRange(
+                    cs.newPositionForModelOffset(endOffset),
+                    cs.newPositionForModelOffset(beginOffset));
+        }
+        else {
+            return new StartEndTextRange(
+                    cs.newPositionForModelOffset(beginOffset),
+                    cs.newPositionForModelOffset(endOffset));
+        }
     }
 
     public static TextRange exclusive(Position from, Position to) {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -176,10 +176,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
             // is placed in the line below the selection by eclipse. this
             // corrects that behaviour
             if (ContentType.LINES.equals(newSelection.getContentType(configuration))) {
-                if (newSelection.isReversed()) {
-                    from -= 1;
-                    length += 1;
-                } else {
+                if (!newSelection.isReversed()) {
                     length -=1;
                 }
             }


### PR DESCRIPTION
Lets have two lines. When we move the cursor on the second line, select the linewise visual mode and move upwards to the first line, then the cursor remains at the second line, although the selection range changes. This commit fixes it, cursor should be able to move upwards. This fix is rather cosmetic, but it should be clear now, how the selection range will change on motion (the change occurs at line with cursor).
