### PR TITLE
Implemented Vim's 'cursorline' option

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/UnderlyingEditorSettings.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/UnderlyingEditorSettings.java
@@ -4,5 +4,6 @@ public interface UnderlyingEditorSettings {
     void setReplaceMode(boolean replace);
     void setShowLineNumbers(boolean show);
     void setShowWhitespace(boolean show);
+    void setHighlightCursorLine(boolean highlight);
     void disableInputMethod();
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
@@ -12,28 +12,29 @@ import net.sourceforge.vrapper.platform.Configuration.Option;
 
 public interface Options {
     // Boolean options:
-    public static final Option<Boolean> SMART_INDENT       = bool("smartindent",  true,  "si");
-    public static final Option<Boolean> AUTO_INDENT        = bool("autoindent",   false, "ai");
-    public static final Option<Boolean> ATOMIC_INSERT      = bool("atomicinsert", true,  "ati");
-    public static final Option<Boolean> IGNORE_CASE        = bool("ignorecase",   false, "ic");
-    public static final Option<Boolean> SMART_CASE         = bool("smartcase",    false, "scs");
-    public static final Option<Boolean> SANE_CW            = bool("sanecw",       false);
-    public static final Option<Boolean> SANE_Y             = bool("saney",        false);
-    public static final Option<Boolean> SEARCH_HIGHLIGHT   = bool("hlsearch",     false, "hls");
-    public static final Option<Boolean> SEARCH_REGEX       = bool("regexsearch",  false, "rxs");
-    public static final Option<Boolean> INCREMENTAL_SEARCH = bool("incsearch",    false, "is");
-    public static final Option<Boolean> LINE_NUMBERS       = bool("number",       false, "nu");
-    public static final Option<Boolean> SHOW_WHITESPACE    = bool("list",         false, "l");
-    public static final Option<Boolean> IM_DISABLE         = bool("imdisable",    false, "imd");
-    public static final Option<Boolean> VISUAL_MOUSE       = bool("visualmouse",  true,  "vm");
-    public static final Option<Boolean> AUTO_CHDIR         = bool("autochdir",    false, "acd");
+    public static final Option<Boolean> SMART_INDENT          = bool("smartindent",  true,  "si");
+    public static final Option<Boolean> AUTO_INDENT           = bool("autoindent",   false, "ai");
+    public static final Option<Boolean> ATOMIC_INSERT         = bool("atomicinsert", true,  "ati");
+    public static final Option<Boolean> IGNORE_CASE           = bool("ignorecase",   false, "ic");
+    public static final Option<Boolean> SMART_CASE            = bool("smartcase",    false, "scs");
+    public static final Option<Boolean> SANE_CW               = bool("sanecw",       false);
+    public static final Option<Boolean> SANE_Y                = bool("saney",        false);
+    public static final Option<Boolean> SEARCH_HIGHLIGHT      = bool("hlsearch",     false, "hls");
+    public static final Option<Boolean> SEARCH_REGEX          = bool("regexsearch",  false, "rxs");
+    public static final Option<Boolean> INCREMENTAL_SEARCH    = bool("incsearch",    false, "is");
+    public static final Option<Boolean> LINE_NUMBERS          = bool("number",       false, "nu");
+    public static final Option<Boolean> SHOW_WHITESPACE       = bool("list",         false);
+    public static final Option<Boolean> IM_DISABLE            = bool("imdisable",    false, "imd");
+    public static final Option<Boolean> VISUAL_MOUSE          = bool("visualmouse",  true,  "vm");
+    public static final Option<Boolean> AUTO_CHDIR            = bool("autochdir",    false, "acd");
+    public static final Option<Boolean> HIGHLIGHT_CURSOR_LINE = bool("cursorline",   false, "cul");
 
     @SuppressWarnings("unchecked")
     public static final Set<Option<Boolean>> BOOLEAN_OPTIONS = set(
             SMART_INDENT, AUTO_INDENT, ATOMIC_INSERT, IGNORE_CASE, SMART_CASE,
             SANE_CW, SANE_Y, SEARCH_HIGHLIGHT, SEARCH_REGEX,
             INCREMENTAL_SEARCH, LINE_NUMBERS, SHOW_WHITESPACE, IM_DISABLE,
-            VISUAL_MOUSE, AUTO_CHDIR);
+            VISUAL_MOUSE, AUTO_CHDIR, HIGHLIGHT_CURSOR_LINE);
 
     // String options:
     public static final Option<String> CLIPBOARD = string("clipboard", "autoselect", "unnamed, autoselect", "cb");

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
@@ -297,23 +297,25 @@ public class CommandLineParser extends AbstractCommandParser {
             }
         }
         // overwrites hlsearch/nohlsearch commands
-        Evaluator numberToggle = new OptionDependentEvaluator(Options.LINE_NUMBERS, ConfigAction.NO_LINE_NUMBERS, ConfigAction.LINE_NUMBERS);
-        Evaluator listToggle = new OptionDependentEvaluator(Options.SHOW_WHITESPACE, ConfigAction.NO_SHOW_WHITESPACE, ConfigAction.SHOW_WHITESPACE);
         config.add("globalregisters", ConfigAction.GLOBAL_REGISTERS);
         config.add("noglobalregisters", ConfigAction.NO_GLOBAL_REGISTERS);
         config.add("localregisters", ConfigAction.NO_GLOBAL_REGISTERS);
         config.add("nolocalregisters", ConfigAction.GLOBAL_REGISTERS);
-        config.add("number", ConfigAction.LINE_NUMBERS);
-        config.add("nonumber", ConfigAction.NO_LINE_NUMBERS);
-        config.add("nu", ConfigAction.LINE_NUMBERS);
-        config.add("nonu", ConfigAction.NO_LINE_NUMBERS);
-        config.add("number!", numberToggle);
-        config.add("nu!", numberToggle);
-        config.add("list", ConfigAction.SHOW_WHITESPACE);
-        config.add("nolist", ConfigAction.NO_SHOW_WHITESPACE);
-        config.add("list!", listToggle);
+        addActionsToBooleanOption(config, Options.LINE_NUMBERS, ConfigAction.LINE_NUMBERS, ConfigAction.NO_LINE_NUMBERS);
+        addActionsToBooleanOption(config, Options.SHOW_WHITESPACE, ConfigAction.SHOW_WHITESPACE, ConfigAction.NO_SHOW_WHITESPACE);
+        addActionsToBooleanOption(config, Options.HIGHLIGHT_CURSOR_LINE, ConfigAction.HIGHLIGHT_CURSOR_LINE, ConfigAction.NO_HIGHLIGHT_CURSOR_LINE);
 
         return config;
+    }
+    
+    private static void addActionsToBooleanOption(EvaluatorMapping config,
+            Option<Boolean> option, ConfigAction enable, ConfigAction disable) {
+        Evaluator toggle = new OptionDependentEvaluator(option, disable, enable);
+        for (String alias : option.getAllNames()) {
+            config.add(alias, enable);
+            config.add("no" + alias, disable);
+            config.add(alias + "!", toggle);
+        }
     }
 
     public CommandLineParser(EditorAdaptor vim) {
@@ -449,6 +451,20 @@ public class CommandLineParser extends AbstractCommandParser {
             public Object evaluate(EditorAdaptor vim, Queue<String> command) {
                 vim.getConfiguration().set(Options.SHOW_WHITESPACE, Boolean.FALSE);
                 vim.getEditorSettings().setShowWhitespace(false);
+                return null;
+            }
+        },
+        HIGHLIGHT_CURSOR_LINE {
+            public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+                vim.getConfiguration().set(Options.HIGHLIGHT_CURSOR_LINE, Boolean.TRUE);
+                vim.getEditorSettings().setHighlightCursorLine(true);
+                return null;
+            }
+        },
+        NO_HIGHLIGHT_CURSOR_LINE {
+            public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+                vim.getConfiguration().set(Options.HIGHLIGHT_CURSOR_LINE, Boolean.FALSE);
+                vim.getEditorSettings().setHighlightCursorLine(false);
                 return null;
             }
         }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/AbstractTextEditorSettings.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/AbstractTextEditorSettings.java
@@ -44,6 +44,10 @@ public class AbstractTextEditorSettings implements UnderlyingEditorSettings {
         EditorsUI.getPreferenceStore().setValue(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SHOW_WHITESPACE_CHARACTERS , show);
     }
     
+    public void setHighlightCursorLine(boolean highlight) {
+        EditorsUI.getPreferenceStore().setValue(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_CURRENT_LINE , highlight);
+    }
+
     public void disableInputMethod() {
         //Reset IME (Input Method editor) so Japanese keyboards can use normal-mode's key-bindings
         Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();


### PR DESCRIPTION
(1) I implemented a 'cursorline' option, which allows to enable/disable highlighting of the line with cursor.

(2) Removed alias 'l' for 'list' option (not specified in Vim's documentation)
