### PR TITLE
Fixes #177 : use Java 6 (JavaSE-1.6) in all project config files

### DIFF
--- a/net.sourceforge.vrapper.core.tests/.classpath
+++ b/net.sourceforge.vrapper.core.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="/net.sourceforge.vrapper.plugin.surround.eclipse"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>

--- a/net.sourceforge.vrapper.core.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.core.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,11 @@
-#Fri Apr 17 23:52:15 CEST 2009
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.core/.classpath
+++ b/net.sourceforge.vrapper.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.core/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.core/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,11 @@
-#Fri Apr 17 20:24:31 CEST 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.compliance=1.6
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.core/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.core/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Export-Package: net.sourceforge.vrapper.keymap,
  net.sourceforge.vrapper.vim.modes,
  net.sourceforge.vrapper.vim.modes.commandline,
  net.sourceforge.vrapper.vim.register
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BuddyPolicy: dependent

--- a/net.sourceforge.vrapper.eclipse.cdt/.classpath
+++ b/net.sourceforge.vrapper.eclipse.cdt/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.eclipse.cdt/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.eclipse.cdt/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,11 @@
-#Wed Nov 04 18:13:13 GMT 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.eclipse.cdt/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.eclipse.cdt/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: net.sourceforge.vrapper.eclipse.cdt;singleton:=true
 Bundle-Version: 0.29.20130311
 Fragment-Host: net.sourceforge.vrapper.eclipse;bundle-version="0.29.20130311"
 Require-Bundle: org.eclipse.cdt.ui;bundle-version="5.1.1"
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/net.sourceforge.vrapper.eclipse.jdt/.classpath
+++ b/net.sourceforge.vrapper.eclipse.jdt/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.eclipse.jdt/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.eclipse.jdt/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,11 @@
-#Tue Nov 03 02:26:32 GMT 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.eclipse.jdt/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.eclipse.jdt/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: net.sourceforge.vrapper.eclipse.jdt;singleton:=true
 Bundle-Version: 0.29.20130311
 Fragment-Host: net.sourceforge.vrapper.eclipse;bundle-version="0.29.20130311"
 Require-Bundle: org.eclipse.jdt.ui;bundle-version="3.5.1"
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/net.sourceforge.vrapper.eclipse.pydev/.classpath
+++ b/net.sourceforge.vrapper.eclipse.pydev/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.eclipse.pydev/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.eclipse.pydev/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,11 @@
-#Tue Nov 03 02:26:32 GMT 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.eclipse.pydev/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.eclipse.pydev/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: net.sourceforge.vrapper.eclipse.pydev;singleton:=true
 Bundle-Version: 0.29.20130311
 Fragment-Host: net.sourceforge.vrapper.eclipse;bundle-version="0.29.20130311"
 Require-Bundle: org.python.pydev;bundle-version="2.6.0"
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/net.sourceforge.vrapper.eclipse.tests/.classpath
+++ b/net.sourceforge.vrapper.eclipse.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.eclipse.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.eclipse.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,11 @@
-#Sat Apr 18 00:18:03 CEST 2009
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.eclipse.tests/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.eclipse.tests/META-INF/MANIFEST.MF
@@ -7,4 +7,4 @@ Bundle-Activator: net.sourceforge.vrapper.eclipse.tests.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/net.sourceforge.vrapper.eclipse/.classpath
+++ b/net.sourceforge.vrapper.eclipse/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.eclipse/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.eclipse/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,11 @@
-#Fri Apr 17 20:25:28 CEST 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.compliance=1.6
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.eclipse/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.eclipse/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide,
  org.eclipse.core.resources,
  net.sourceforge.vrapper.core;bundle-version="0.29.20130311";visibility:=reexport
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: net.sourceforge.vrapper.eclipse.commands;
   uses:="net.sourceforge.vrapper.vim.commands.motions,
    net.sourceforge.vrapper.vim.commands,

--- a/net.sourceforge.vrapper.plugin.surround.core/.classpath
+++ b/net.sourceforge.vrapper.plugin.surround.core/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.plugin.surround.core/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.plugin.surround.core/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,11 @@
-#Thu Nov 05 19:20:53 GMT 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.plugin.surround.core/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.plugin.surround.core/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 0.29.20130311
 Export-Package: net.sourceforge.vrapper.plugin.surround.commands,
  net.sourceforge.vrapper.plugin.surround.state
 Require-Bundle: net.sourceforge.vrapper.core;bundle-version="0.29.20130311";visibility:=reexport
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BuddyPolicy: dependent

--- a/net.sourceforge.vrapper.plugin.surround.eclipse/.classpath
+++ b/net.sourceforge.vrapper.plugin.surround.eclipse/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/net.sourceforge.vrapper.plugin.surround.eclipse/.settings/org.eclipse.jdt.core.prefs
+++ b/net.sourceforge.vrapper.plugin.surround.eclipse/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,11 @@
-#Thu Nov 05 18:38:39 GMT 2009
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.source=1.6

--- a/net.sourceforge.vrapper.plugin.surround.eclipse/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.plugin.surround.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vrapper Surround Plug-in Eclipse integration
 Bundle-SymbolicName: net.sourceforge.vrapper.plugin.surround.eclipse;singleton:=true
 Bundle-Version: 0.29.20130311
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: net.sourceforge.vrapper.plugin.surround.core;bundle-version="0.29.20130311";visibility:=reexport,
  net.sourceforge.vrapper.eclipse
 Eclipse-BuddyPolicy: dependent


### PR DESCRIPTION
Copied from #177:

I wanted to take a look at the newest Vrapper sources, but my Eclipse wouldn't compile them. It spits out an error on String.isEmpty().

Now it so happens that Vrapper was started when Java 1.5 was still a supported target, in the mean time it seems that everybody removed it from his computer and simply forced a 1.6 or 1.7 JDK in the 1.5 execution environment, hence confusing Eclipse.

I am willing to find/replace in the project files, but what is the stance of others? Should we shoot for 1.6 or 1.7 minimum level?

---

Odd that the previous issue gets no merge button - I thought github also offered it when commits are referenced in an issue.
