### PR TITLE
modified method stubs to make test pass

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 import java.util.Queue;
@@ -107,6 +108,9 @@ public class CommandLineTests extends VimTestCase {
     @Test
     public void testRetab() throws CommandExecutionException {
     	SimpleTextOperation retabCommand = (SimpleTextOperation) new RetabOperation(null);
+    
+    	when(configuration.get(Options.EXPAND_TAB)).thenReturn(true);
+    	when(configuration.get(Options.TAB_STOP)).thenReturn(4);
     	
     	content.setText("\t");
     	retabCommand.execute(adaptor, null, ContentType.LINES);


### PR DESCRIPTION
I'm still pretty new to making pull requests and the like, so apologies if I do something wrong.

I'd like to make some contributions to vrapper, but I noticed that this test wasn't passing. I mocked the configurations to return the right values as I saw done in NormalModeTests, which caused the test to pass.

Hopefully I'm not just looking at the wrong source and this was fixed already.
