### PR TITLE
Add support for Vim's _ motion

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MotionTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MotionTests.java
@@ -127,6 +127,44 @@ public class MotionTests extends CommandTestCase {
 				"something ", 's', "omething\n	something something\nelse",
 				"something something\n	", 's', "omething something\nelse");
 	}
+	   
+    @Test
+    public void testMoveDownLessOne() {
+        Motion moveDownLessOne = MoveUpDownNonWhitespace.MOVE_DOWN_LESS_ONE;
+        checkMotion(moveDownLessOne,
+                "something ", 's', "omething",
+                "", 's', "omething something");
+        
+        //should stay on the same line
+        checkMotion(moveDownLessOne,
+                "line 1\nlin",'e'," 2\nline 3",
+                "line 1\n",'l',"ine 2\nline 3");
+        
+        checkMotion(moveDownLessOne,
+                "line 1\nline 2\nli",'n',"e 3",
+                "line 1\nline 2\n",'l',"ine 3");
+        
+        //the motion needs to be given a count of 2 to actually move down
+        checkMotion(moveDownLessOne, 2,
+                "something ", 's', "omething\nsomething something\nelse",
+                "something something\n", 's', "omething something\nelse");
+        
+        //otherwise it stays on the current line
+        checkMotion(moveDownLessOne,
+                "something ", 's', "omething\nsomething something\nelse",
+                "",'s',"omething something\nsomething something\nelse");
+        
+        //leading spaces
+        checkMotion(moveDownLessOne,
+                "    something ", 's', "omething\nsomething else",
+                "    ",'s',"omething something\nsomething else");
+        
+        //leading tab
+        checkMotion(moveDownLessOne,
+                "   something ", 's', "omething",
+                "   ",'s',"omething something");
+    
+    }
 
 	public void testCommonMoveWordWORDRight(Motion wordMotion) {
 		// simple stuff

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveUpDownNonWhitespace.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/MoveUpDownNonWhitespace.java
@@ -12,23 +12,27 @@ import net.sourceforge.vrapper.vim.commands.MotionCommand;
  */
 public class MoveUpDownNonWhitespace extends CountAwareMotion {
 
-    public static final MoveUpDownNonWhitespace MOVE_DOWN = new MoveUpDownNonWhitespace(true);
-    public static final MoveUpDownNonWhitespace MOVE_UP = new MoveUpDownNonWhitespace(false);
+    public static final MoveUpDownNonWhitespace MOVE_DOWN_LESS_ONE = new MoveUpDownNonWhitespace(true, 0);
+    public static final MoveUpDownNonWhitespace MOVE_DOWN = new MoveUpDownNonWhitespace(true, 1);
+    public static final MoveUpDownNonWhitespace MOVE_UP = new MoveUpDownNonWhitespace(false, 1);
     private boolean down = false;
-    
-    private MoveUpDownNonWhitespace(boolean down) {
-    	this.down = down;
+    private int defaultAmount = 1;
+
+    private MoveUpDownNonWhitespace(boolean down, int defaultAmount) {
+        this.down = down;
+        this.defaultAmount = defaultAmount;
     }
 
     @Override
-    public Position destination(EditorAdaptor editorAdaptor, int count)
-            throws CommandExecutionException {
-    	if(down) {
-    		MotionCommand.doIt(editorAdaptor, MoveDown.INSTANCE.withCount(count));
-    	}
-    	else {
-    		MotionCommand.doIt(editorAdaptor, MoveUp.INSTANCE.withCount(count));
-    	}
+    public Position destination(EditorAdaptor editorAdaptor, int count) throws CommandExecutionException {
+        int linesToMove = count + defaultAmount;
+        if (linesToMove > 0) {
+            if (down) {
+                MotionCommand.doIt(editorAdaptor, MoveDown.INSTANCE.withCount(linesToMove - 1));
+            } else {
+                MotionCommand.doIt(editorAdaptor, MoveUp.INSTANCE.withCount(linesToMove - 1));
+            }
+        }
         return LineStartMotion.NON_WHITESPACE.destination(editorAdaptor);
     }
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/CommandBasedMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/CommandBasedMode.java
@@ -99,6 +99,7 @@ public abstract class CommandBasedMode extends AbstractMode {
             final Motion moveUp = MoveUp.INSTANCE;
             final Motion moveDown = MoveDown.INSTANCE;
             final Motion moveDownNonWhitespace = MoveUpDownNonWhitespace.MOVE_DOWN;
+            final Motion moveDownLessOneNonWhitespace = MoveUpDownNonWhitespace.MOVE_DOWN_LESS_ONE;
             final Motion moveUpNonWhitespace = MoveUpDownNonWhitespace.MOVE_UP;
             final Motion moveToColumn = MoveToColumn.INSTANCE;
             final Motion findNext = SearchResultMotion.FORWARD;
@@ -150,6 +151,7 @@ public abstract class CommandBasedMode extends AbstractMode {
                     leafBind(SpecialKey.RETURN, moveDownNonWhitespace),
                     leafBind('+', moveDownNonWhitespace),
                     leafBind('-', moveUpNonWhitespace),
+                    leafBind('_', moveDownLessOneNonWhitespace),
                     leafBind(' ', (Motion) MoveRightAcrossLines.INSTANCE),
                     leafBind(SpecialKey.BACKSPACE, (Motion) MoveLeftAcrossLines.INSTANCE),
                     leafBind(SpecialKey.ARROW_LEFT, moveLeft),


### PR DESCRIPTION
From Vim's help files:

```
+               or                                      +
CTRL-M          or                                      CTRL-M <CR>
<CR>                    [count] lines downward, on the first non-blank
                        character linewise.

                                                        _
_  <underscore>         [count] - 1 lines downward, on the first non-blank
                        character linewise.
```

Since _ is + with a default of one less count, I added it to the same file as + and -. I couldn't directly implement it by taking away one, since a count of 0 is interpreted as no count given, so that case is handled separately.
