### PR TITLE
Make paragraphs and sentences considered jumps

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ParagraphMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ParagraphMotion.java
@@ -80,6 +80,11 @@ public class ParagraphMotion extends CountAwareMotion {
     public boolean updateStickyColumn() {
         return true;
     }
+    
+    @Override
+    public boolean isJump() {
+        return true;
+    }
 
     public static class ParagraphTextObject extends AbstractTextObject {
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/SentenceMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/SentenceMotion.java
@@ -141,4 +141,9 @@ public class SentenceMotion extends CountAwareMotion {
 	public boolean updateStickyColumn() {
 		return true;
 	}
+	
+	@Override
+	public boolean isJump() {
+	    return true;
+	}
 }


### PR DESCRIPTION
Surprisingly, paragraph and sentence motions are considered jumps. 

All the motions that are jumps are in :h jump-motions:

```
A "jump" is one of the following commands: "'", "`", "G", "/", "?", "n",
"N", "%", "(", ")", "[[", "]]", "{", "}", ":s", ":tag", "L", "M", "H" 
```

 I just overrode the isJump method in the motions, and it seemed to work fine.
