### PR TITLE
Fix the behaviour of Tag Objects

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MotionTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MotionTests.java
@@ -487,6 +487,7 @@ public class MotionTests extends CommandTestCase {
 				"", 'S', "o" + longWord + "isntit");
 	}
 
+
 	public void testCommonMoveWordWORDEndLeft(Motion wordMotion) {
 		// simple stuff
 		checkMotion(wordMotion,
@@ -573,7 +574,6 @@ public class MotionTests extends CommandTestCase {
 
 	@Test
 	public void testMoveWORDEndLeft() {
-
 		Motion moveWORDEndLeft = MoveBigWORDEndLeft.INSTANCE;
 
 		testCommonMoveWordWORDEndLeft(moveWORDEndLeft);
@@ -798,6 +798,7 @@ public class MotionTests extends CommandTestCase {
                 "e",'i',"ns\n\nzwei\n\ndrei\n\nPolizei!",
                 "eins\n\nzwei\n\ndrei\n",'\n',"Polizei!");
     }
+
 	
 	@Test
     public void testParagraphBackwardMotion() {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/test
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/test
@@ -1,2 +1,0 @@
-<content>
-<tag>content</tag>


### PR DESCRIPTION
This fixes three issues I am aware of:
- The behaviour outlined in #192, related to the cursor being inside of a tag
- Vim searches for an opening tag first, then looks for a closing tag to match it. Originally the Vrapper behaviour was the opposite, this fixes that. This only really matters in cases like the test `test_dit_interweaved`
- Adds support for testing and some tests for tags.

I believe I added tests for all the cases that can come up, but please take a look and make sure there aren't any I missed :) There's also one case that I wrote a test for and marked as "Ignore", since it's pretty tricky and I'm not sure how to approach it yet.

The general algorithm is the same as the one that was there before, this pretty much just handles some edge cases and other things.
