### PR TITLE
Fixed problem related to empty-element tags with XML tag text objects

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
@@ -715,6 +715,21 @@ public class NormalModeTests extends CommandTestCase {
                 "<tag>",'<',"/tag>");
 	}
 	
+    @Test
+    public void test_dit_singleTag() {
+        checkCommand(forKeySeq("dit"),
+                "<tag><tag/>co",'n',"tent</tag>",
+                "<tag>",'<',"/tag>");
+        
+        checkCommand(forKeySeq("dit"),
+                "<tag>co",'n',"tent<tag/></tag>",
+                "<tag>",'<',"/tag>");
+        
+        checkCommand(forKeySeq("dit"),
+                "<tag><tag/>co",'n',"tent<tag/></tag>",
+                "<tag>",'<',"/tag>");
+    }
+	
 	@Test
 	public void test_2dit() {
         checkCommand(forKeySeq("2dit"),

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/XmlTagDelimitedText.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/XmlTagDelimitedText.java
@@ -22,7 +22,7 @@ public class XmlTagDelimitedText implements DelimitedText {
     //regex usually stops at newlines but open tags might have
     //multiple lines of attributes.  So, include newlines in search.
     
-    private static final String XML_TAG_REGEX = "<([^<]|\n)*?>";
+    private static final String XML_TAG_REGEX = "<([^<]|\n)*?[^/]>";
     
     private static final Pattern tagPattern = Pattern.compile(XML_TAG_REGEX);
     


### PR DESCRIPTION
I found another problem with my work, basically it didn't ignore empty elements properly, as you can see in the test cases that I included. I made a change to the regular expression that excludes these, which fixes the problem.
