### PR TITLE
Ignore comments in XML, and add tests to verify

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
@@ -695,6 +695,16 @@ public class NormalModeTests extends CommandTestCase {
 	}
 	
 	@Test
+	public void test_dit_comment() {
+        checkCommand(forKeySeq("dit"),
+                "<tag><!-- comment -->",' ',"</tag>",
+                "<tag>",'<',"/tag>");
+        checkCommand(forKeySeq("dit"),
+                "<tag>",'<',"!-- comment --></tag>",
+                "<tag>",'<',"/tag>");
+	}
+	
+	@Test
 	public void test_dit_multiline() {
         checkCommand(forKeySeq("dit"),
                 "<tag\nother>co",'n',"tent</tag>",

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/XmlTagDelimitedText.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/XmlTagDelimitedText.java
@@ -22,7 +22,7 @@ public class XmlTagDelimitedText implements DelimitedText {
     //regex usually stops at newlines but open tags might have
     //multiple lines of attributes.  So, include newlines in search.
     
-    private static final String XML_TAG_REGEX = "<([^<]|\n)*?[^/]>";
+    private static final String XML_TAG_REGEX = "<([^<!]|\n)*?[^/]>";
     
     private static final Pattern tagPattern = Pattern.compile(XML_TAG_REGEX);
     


### PR DESCRIPTION
Fixes the problem brought up in https://github.com/vrapper/vrapper/pull/194#issuecomment-17340471.

It just makes comments not considered XML tags at all.
