### PR TITLE
Add PlatformSpecificModeProvider extension point

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/Platform.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/Platform.java
@@ -16,5 +16,6 @@ public interface Platform {
     UnderlyingEditorSettings getUnderlyingEditorSettings();
     Configuration getConfiguration();
     PlatformSpecificStateProvider getPlatformSpecificStateProvider();
+    PlatformSpecificModeProvider getPlatformSpecificModeProvider();
     SearchAndReplaceService getSearchAndReplaceService();
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/PlatformSpecificModeProvider.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/PlatformSpecificModeProvider.java
@@ -1,0 +1,35 @@
+package net.sourceforge.vrapper.platform;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.modes.EditorMode;
+
+/**
+ * Provides extra {@link EditorMode} implementations in case of interactive plugins.
+ * <p>
+ * Commands to switch to these new modes should be passed through a
+ *  {@link PlatformSpecificStateProvider} implementation.
+ *
+ * @author Bert Jacobs
+ */
+public interface PlatformSpecificModeProvider {
+    
+    /**
+     * @return a {@link List} of extended {@link EditorMode}s
+     *  or {@link Collections#emptyList()}.
+     * 
+     * <p>Each mode's name should be unique to prevent clashes when switching modes. Preferably use
+     *  the FQCN of the class implementing the mode.
+     * <p>The display name of the modes are up to the implementer, though it is advised to use
+     *  something different from the standard modes so the user doesn't get confused.
+     */
+    List<EditorMode> getModes(EditorAdaptor editorAdaptor);
+    
+    /**
+     * @return name of this {@link PlatformSpecificModeProvider} (for debugging purposes)
+     */
+    String getName();
+    
+}

--- a/net.sourceforge.vrapper.eclipse/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.eclipse/META-INF/MANIFEST.MF
@@ -25,5 +25,8 @@ Export-Package: net.sourceforge.vrapper.eclipse.commands;
    net.sourceforge.vrapper.keymap,
    net.sourceforge.vrapper.eclipse.commands,
    net.sourceforge.vrapper.platform,
-   net.sourceforge.vrapper.vim"
+   net.sourceforge.vrapper.vim",
+ net.sourceforge.vrapper.eclipse.mode;
+  uses:="net.sourceforge.vrapper.vim.modes,
+   net.sourceforge.vrapper.platform"
 Eclipse-BuddyPolicy: dependent

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -3,6 +3,7 @@
 <plugin>
    <extension-point id="net.sourceforge.vrapper.eclipse.pssp" name="Platform Specific State Provider" schema="schema/net.sourceforge.vrapper.eclipse.pssp.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.extractor" name="Text Editor Extractor" schema="schema/net.sourceforge.vrapper.eclipse.extractor.exsd"/>
+   <extension-point id="net.sourceforge.vrapper.eclipse.psmp" name="Platform Specific Mode Provider" schema="schema/net.sourceforge.vrapper.eclipse.psmp.exsd"/>
   <extension
        point="org.eclipse.ui.commands">
     <category

--- a/net.sourceforge.vrapper.eclipse/schema/net.sourceforge.vrapper.eclipse.psmp.exsd
+++ b/net.sourceforge.vrapper.eclipse/schema/net.sourceforge.vrapper.eclipse.psmp.exsd
@@ -1,0 +1,119 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="net.sourceforge.vrapper.eclipse" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="net.sourceforge.vrapper.eclipse" id="net.sourceforge.vrapper.eclipse.psmp" name="Platform Specific Mode Provider"/>
+      </appInfo>
+      <documentation>
+         Extension that defines Platform Specific Mode Providers.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="mode-provider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="mode-provider">
+      <complexType>
+         <attribute name="name" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="identifier"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="provider-class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn="net.sourceforge.vrapper.eclipse.mode.AbstractEclipseSpecificModeProvider:"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         0.31.0
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/mode/AbstractEclipseSpecificModeProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/mode/AbstractEclipseSpecificModeProvider.java
@@ -1,0 +1,28 @@
+package net.sourceforge.vrapper.eclipse.mode;
+
+import net.sourceforge.vrapper.platform.PlatformSpecificModeProvider;
+
+/**
+ * Base implementation of {@link PlatformSpecificModeProvider} to provide new command line
+ * modes.
+ * 
+ * @author jacobsb
+ */
+public abstract class AbstractEclipseSpecificModeProvider
+        implements PlatformSpecificModeProvider {
+    
+    protected String name;
+    
+    public AbstractEclipseSpecificModeProvider(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+    
+    public String toString() {
+        return name;
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/mode/UnionModeProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/mode/UnionModeProvider.java
@@ -1,0 +1,27 @@
+package net.sourceforge.vrapper.eclipse.mode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.modes.EditorMode;
+
+public class UnionModeProvider extends AbstractEclipseSpecificModeProvider {
+
+    private List<AbstractEclipseSpecificModeProvider> providers;
+
+    public UnionModeProvider(String name, List<AbstractEclipseSpecificModeProvider> providers) {
+        super(name);
+        this.providers = providers;
+    }
+
+    @Override
+    public List<EditorMode> getModes(EditorAdaptor editorAdaptor) {
+        List<EditorMode> extensionModes = new ArrayList<EditorMode>();
+        for (AbstractEclipseSpecificModeProvider provider : providers) {
+            extensionModes.addAll(provider.getModes(editorAdaptor));
+        }
+        return extensionModes;
+    }
+
+}


### PR DESCRIPTION
I'm currently trying to implement another feature of Surround.vim into the Surround plugin: XML tag replacing. For this, I need a command-line like mode, but I found no way to add new modes from a plugin.

This pull request provides the basic stuff needed to add modes through an extension point. Anyone implementing a new mode needs to make both a state provider to provide a ChangeModeCommand and a mode provider to actually hook in the new mode.
Key parsing is then handled in the mode's handleKey method, so no other changes should be necessary. You can't override existing modes nor can you define a mode twice. The modes are currently lazily initialized, it's only when a ChangeModeCommand to an extension mode is given that will they all be loaded.

Note that I stripped out the editor detection logic. It could have been nice to keep it, but I didn't see the point given that you can only switch to an extension mode if its state provider got loaded (and that one is editor-aware).
