### PR TITLE
Surround customization command.

### DIFF
--- a/net.sourceforge.vrapper.plugin.surround.core/src/net/sourceforge/vrapper/plugin/surround/state/DelimiterValues.java
+++ b/net.sourceforge.vrapper.plugin.surround.core/src/net/sourceforge/vrapper/plugin/surround/state/DelimiterValues.java
@@ -1,13 +1,30 @@
 package net.sourceforge.vrapper.plugin.surround.state;
-
+import static java.util.Arrays.asList;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafBind;
-import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.state;
-import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.HashMapState;
+import net.sourceforge.vrapper.keymap.KeyBinding;
 
 public class DelimiterValues {
 
+    public static class DelimiterState extends HashMapState<DelimiterHolder> {
+
+        // Extensible state to be used to dynamically add new surrounds.
+        public DelimiterState(KeyBinding<DelimiterHolder>... bindings) {
+            super(asList(bindings));
+        }
+
+        public void addDelimiterHolder(char key, String left, String right)
+        {
+            KeyBinding<DelimiterHolder> binding =
+                    leafBind(key, (DelimiterHolder) new SimpleDelimiterHolder(left, right));
+            map.put(binding.getKeyPress(), binding.getTransition());
+        }
+
+    }
+
     @SuppressWarnings("unchecked")
-    public static final State<DelimiterHolder> DELIMITER_HOLDERS = state(
+    public static DelimiterState DELIMITER_HOLDERS =
+        new DelimiterState(
             leafBind('b', (DelimiterHolder) new SimpleDelimiterHolder("(",")")),
             leafBind('(', (DelimiterHolder) new SimpleDelimiterHolder("( "," )")),
             leafBind(')', (DelimiterHolder) new SimpleDelimiterHolder("(",")")),


### PR DESCRIPTION
Adds :surround <char> <definition> command to define new or redefine
existing replacements.
<definition> must not contain spaces but '<SPACE>' can be used if needed.
The surround point is specified by '\r':
:surround \ /_<SPACE>\r<SPACE>_/
:surround / /_\r_/
