### PR TITLE
Editor split improvements.

### DIFF
--- a/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/MoveEditorCommand.java
+++ b/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/MoveEditorCommand.java
@@ -41,7 +41,6 @@ public class MoveEditorCommand extends AbstractWindowCommand {
         IWorkbenchPartSite site = getEditorSite();
         EPartService psvc = (EPartService) site.getService(EPartService.class);
         MPartStack stack = findAdjacentStack(site, direction);
-        EModelService svc = (EModelService) site.getService(EModelService.class);
         MPart p = (MPart) site.getService(MPart.class);
         MElementContainer<MUIElement> editorStack = p.getParent();
 

--- a/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/SplitContainer.java
+++ b/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/SplitContainer.java
@@ -1,0 +1,17 @@
+package net.sourceforge.vrapper.plugin.splitEditor.commands;
+
+/**
+ * Editor split option regarding shared area (MArea).
+ */
+public enum SplitContainer {
+    /**
+     * Make the new split in the shared area if the current editor is in the
+     * shared area.
+     */
+    SHARED_AREA,
+    /**
+     * New split always goes to the top-level container leaving the shared
+     * area untouched.
+     */
+    TOP_LEVEL
+}

--- a/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/provider/WindowCmdStateProvider.java
+++ b/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/provider/WindowCmdStateProvider.java
@@ -4,50 +4,129 @@ import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.ctrlKey;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafBind;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.state;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.transitionBind;
+
+import java.util.Queue;
+
 import net.sourceforge.vrapper.eclipse.keymap.AbstractEclipseSpecificStateProvider;
 import net.sourceforge.vrapper.keymap.SpecialKey;
 import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.MoveEditorCommand;
+import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitContainer;
+import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitDirection;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitEditorCommand;
+import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitMode;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.SwitchEditorCommand;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.modes.commandline.Evaluator;
 
 public class WindowCmdStateProvider extends AbstractEclipseSpecificStateProvider {
 
+    /**
+     * :wincmd command parser.
+     */
+    class WinCmdCommandEvaluator implements Evaluator {
+        @Override
+        public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+            if (command.size() < 1 || command.peek().length() < 1) {
+                vim.getUserInterfaceService().setErrorMessage(":wincmd expects a single argument");
+            }
+            final boolean bang = command.peek().equals("!");
+            if (bang) {
+                command.poll();
+            }
+            Command cmd = null;
+            final String arg = command.poll();
+            switch (arg.charAt(0)) {
+            case 'h': cmd = SwitchEditorCommand.SWITCH_LEFT; break;
+            case 'l': cmd = SwitchEditorCommand.SWITCH_RIGHT; break;
+            case 'k': cmd = SwitchEditorCommand.SWITCH_UP; break;
+            case 'j': cmd = SwitchEditorCommand.SWITCH_DOWN; break;
+            case 'H': cmd = bang ? MoveEditorCommand.CLONE_LEFT  : MoveEditorCommand.MOVE_LEFT; break;
+            case 'L': cmd = bang ? MoveEditorCommand.CLONE_RIGHT : MoveEditorCommand.MOVE_RIGHT; break;
+            case 'K': cmd = bang ? MoveEditorCommand.CLONE_UP    : MoveEditorCommand.MOVE_UP; break;
+            case 'J': cmd = bang ? MoveEditorCommand.CLONE_DOWN  : MoveEditorCommand.MOVE_DOWN; break;
+            }
+            if (cmd != null) {
+                try {
+                    cmd.execute(vim);
+                } catch (CommandExecutionException e) {
+                    VrapperLog.error(":wincmd error", e);
+                    vim.getUserInterfaceService().setErrorMessage(":wincmd error: " + e.getMessage());
+                }
+            } else {
+                vim.getUserInterfaceService().setErrorMessage(":wincmd invalid argument '" + arg + "'");
+            }
+            return null;
+        }
+    }
+
+    /**
+     * :[v]split command evaluator.
+     */
+    class SplitEvaluator implements Evaluator {
+        final SplitDirection direction;
+
+        SplitEvaluator(SplitDirection direction)
+        {
+            this.direction = direction;
+        }
+
+        @Override
+        public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+            final boolean bang = !command.isEmpty() && command.peek().equals("!");
+            SplitMode mode = SplitMode.CLONE;
+            if (bang) {
+                mode = SplitMode.MOVE;
+                command.poll();
+            }
+            SplitContainer containerMode = SplitContainer.SHARED_AREA;
+            if (!command.isEmpty() && command.peek().startsWith("++nos")) {
+                containerMode = SplitContainer.TOP_LEVEL;
+            }
+
+            try {
+                new SplitEditorCommand(direction, mode, containerMode).execute(vim);
+            } catch (CommandExecutionException e) {
+                VrapperLog.error(":[v]split error", e);
+                vim.getUserInterfaceService().setErrorMessage(":[v]split error: " + e.getMessage());
+            }
+            return null;
+        }
+    }
+
     public WindowCmdStateProvider() {
-        commands.add("vsplit", SplitEditorCommand.VSPLIT);
-        commands.add("split", SplitEditorCommand.HSPLIT);
-        commands.add("mvsplit", SplitEditorCommand.VSPLIT_MOVE);
-        commands.add("msplit", SplitEditorCommand.HSPLIT_MOVE);
-        commands.add("wincmd_h", SwitchEditorCommand.SWITCH_LEFT);
-        commands.add("wincmd_l", SwitchEditorCommand.SWITCH_RIGHT);
-        commands.add("wincmd_k", SwitchEditorCommand.SWITCH_UP);
-        commands.add("wincmd_j", SwitchEditorCommand.SWITCH_DOWN);
-        commands.add("wincmd_H", MoveEditorCommand.MOVE_LEFT);
-        commands.add("wincmd_L", MoveEditorCommand.MOVE_RIGHT);
-        commands.add("wincmd_K", MoveEditorCommand.MOVE_UP);
-        commands.add("wincmd_J", MoveEditorCommand.MOVE_DOWN);
-        commands.add("wincmd_Hc", MoveEditorCommand.CLONE_LEFT);
-        commands.add("wincmd_Lc", MoveEditorCommand.CLONE_RIGHT);
-        commands.add("wincmd_Kc", MoveEditorCommand.CLONE_UP);
-        commands.add("wincmd_Jc", MoveEditorCommand.CLONE_DOWN);
+        name = "EditSplit State Provider";
+        commands.add("vsplit", new SplitEvaluator(SplitDirection.VERTICALLY));
+        commands.add("split", new SplitEvaluator(SplitDirection.HORIZONTALLY));
+        commands.add("wincmd", new WinCmdCommandEvaluator());
     }
 
     @Override
     @SuppressWarnings("unchecked")
     protected State<Command> normalModeBindings() {
-        Command switchEditorLeft = SwitchEditorCommand.SWITCH_LEFT;
-        Command switchEditorRight = SwitchEditorCommand.SWITCH_RIGHT;
-        Command switchEditorDown = SwitchEditorCommand.SWITCH_DOWN;
-        Command switchEditorUp = SwitchEditorCommand.SWITCH_UP;
+        final Command vsplit = SplitEditorCommand.VSPLIT;
+        final Command split = SplitEditorCommand.HSPLIT;
+        final Command switchEditorLeft = SwitchEditorCommand.SWITCH_LEFT;
+        final Command switchEditorRight = SwitchEditorCommand.SWITCH_RIGHT;
+        final Command switchEditorDown = SwitchEditorCommand.SWITCH_DOWN;
+        final Command switchEditorUp = SwitchEditorCommand.SWITCH_UP;
 
-        Command cloneEditorLeft = MoveEditorCommand.CLONE_LEFT;
-        Command cloneEditorRight = MoveEditorCommand.CLONE_RIGHT;
-        Command cloneEditorDown = MoveEditorCommand.CLONE_DOWN;
-        Command cloneEditorUp = MoveEditorCommand.CLONE_UP;
+        final Command cloneEditorLeft = MoveEditorCommand.CLONE_LEFT;
+        final Command cloneEditorRight = MoveEditorCommand.CLONE_RIGHT;
+        final Command cloneEditorDown = MoveEditorCommand.CLONE_DOWN;
+        final Command cloneEditorUp = MoveEditorCommand.CLONE_UP;
         return state(transitionBind(
                 ctrlKey('w'),
-                state(leafBind('h', switchEditorLeft),
+                  state(
+                        leafBind('s', split),
+                        leafBind('S', split),
+                        leafBind(ctrlKey('s'), split),
+                        leafBind('v', vsplit),
+                        leafBind(ctrlKey('v'), vsplit),
+                        leafBind('h', switchEditorLeft),
                         leafBind('l', switchEditorRight),
                         leafBind('j', switchEditorDown),
                         leafBind('k', switchEditorUp),
@@ -55,6 +134,10 @@ public class WindowCmdStateProvider extends AbstractEclipseSpecificStateProvider
                         leafBind(SpecialKey.ARROW_LEFT, switchEditorLeft),
                         leafBind(SpecialKey.ARROW_DOWN, switchEditorDown),
                         leafBind(SpecialKey.ARROW_UP, switchEditorUp),
+                        leafBind(ctrlKey('h'), switchEditorLeft),
+                        leafBind(ctrlKey('l'), switchEditorRight),
+                        leafBind(ctrlKey('j'), switchEditorDown),
+                        leafBind(ctrlKey('k'), switchEditorUp),
                         leafBind('H', MoveEditorCommand.MOVE_LEFT),
                         leafBind('L', MoveEditorCommand.MOVE_RIGHT),
                         leafBind('J', MoveEditorCommand.MOVE_DOWN),
@@ -65,8 +148,7 @@ public class WindowCmdStateProvider extends AbstractEclipseSpecificStateProvider
                                 leafBind('l', cloneEditorRight),
                                 leafBind('j', cloneEditorDown),
                                 leafBind('k', cloneEditorUp),
-                                leafBind(SpecialKey.ARROW_RIGHT,
-                                        cloneEditorRight),
+                                leafBind(SpecialKey.ARROW_RIGHT, cloneEditorRight),
                                 leafBind(SpecialKey.ARROW_LEFT, cloneEditorLeft),
                                 leafBind(SpecialKey.ARROW_DOWN, cloneEditorDown),
                                 leafBind(SpecialKey.ARROW_UP, cloneEditorUp)))));


### PR DESCRIPTION
Added wincmd/[v]split command evaluators:

`:wincmd h/j/k/l` - move between splits.
`:wincmd[!] H/J/K/L` - move or clone (with !) editor between splits.
`:[v]split[!] [++nos[hared]]` - split (or detach with !) current editor.
  With `++nos[hared]` option put the new split outside of the shared area.

Made splits contained within the shared area by default as it behaves
more sane this way.

Added more key binding to match VIM.
