### PR TITLE
Implemented `:only` for splits `C-W C-O` and `C-W C-W`.

### DIFF
--- a/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/RemoveOtherWindowsCommand.java
+++ b/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/RemoveOtherWindowsCommand.java
@@ -1,0 +1,104 @@
+package net.sourceforge.vrapper.plugin.splitEditor.commands;
+
+import java.util.ArrayList;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+
+import org.eclipse.e4.ui.model.application.ui.MElementContainer;
+import org.eclipse.e4.ui.model.application.ui.MUIElement;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.PartInitException;
+
+// Eclipse 4 API version 0.10.1 bundled with Eclipse 4.2.1 is considered provisional.
+@SuppressWarnings("restriction")
+/**
+ * Removes all splits except the current by moving/closing editors from other
+ * splits.
+ */
+public class RemoveOtherWindowsCommand extends AbstractWindowCommand {
+    private boolean join;
+    public static final RemoveOtherWindowsCommand REMOVE_CLOSE = new RemoveOtherWindowsCommand(false);
+    public static final RemoveOtherWindowsCommand REMOVE_JOIN = new RemoveOtherWindowsCommand(true);
+
+    private RemoveOtherWindowsCommand(boolean join) {
+        this.join = join;
+    }
+
+    @Override
+    public void execute(EditorAdaptor editorAdaptor)
+            throws CommandExecutionException {
+        IWorkbenchPartSite site = getEditorSite();
+        final EPartService psvc = (EPartService) site.getService(EPartService.class);
+        EModelService svc = (EModelService) site.getService(EModelService.class);
+        final MPart activePart = (MPart) site.getService(MPart.class);
+        final MElementContainer<MUIElement> editorStack = activePart.getParent();
+        final IWorkbenchPage page = site.getPage();
+        IEditorReference[] editors = page.getEditorReferences();
+        final ArrayList<IEditorInput> currentStackEditors = findStackEditors(editorStack, editors);
+        ArrayList<IEditorReference> partsToClose = new ArrayList<IEditorReference>();
+        final ArrayList<MPart> partsToJoin = new ArrayList<MPart>();
+        for (IEditorReference editor : editors) {
+            // Need the part to identify it's input to find file clones.
+            IWorkbenchPart wbPart = editor.getPart(true);
+            if (wbPart != null) {
+                MPart p = (MPart) wbPart.getSite().getService(MPart.class);
+                if (p.getParent() != editorStack) {
+                    try {
+                        IEditorInput input = editor.getEditorInput();
+                        if (!join || currentStackEditors.contains(input)) {
+                            partsToClose.add(editor);
+                        } else {
+                            partsToJoin.add(p);
+                        }
+                    } catch (PartInitException e) {
+                        // Skip the troublesome part.
+                    }
+                }
+            }
+        }
+        // Using page interface rather than model interface for closing editors
+        // to get nice prompts for unsaved editor.
+        page.closeEditors(partsToClose.toArray(new IEditorReference[0]), true);
+        for (MPart p : partsToJoin)
+        {
+            editorStack.getChildren().add(p);
+        }
+        psvc.activate(activePart, true);
+    }
+
+    /**
+     * Find all editor inputs (read files) for the specified editor stack.
+     * @param editorStack containing editor stack.
+     * @param editors list of all editors.
+     * @return filtered editor lists.
+     */
+    private ArrayList<IEditorInput> findStackEditors(
+            MElementContainer<MUIElement> editorStack,
+            IEditorReference[] editors) {
+        ArrayList<IEditorInput> stackEditors = new ArrayList<IEditorInput>();
+        for (IEditorReference editor : editors)
+        {
+            IWorkbenchPart wbPart = editor.getPart(true);
+            if (wbPart != null) {
+                MPart p = (MPart) wbPart.getSite().getService(MPart.class);
+                if (p.getParent() == editorStack) {
+                    try {
+                        // NOTE: duplicates within the stack are fine.
+                        stackEditors.add(editor.getEditorInput());
+                    } catch (PartInitException e) {
+                        // Ignore.
+                    }
+                }
+            }
+        }
+        return stackEditors;
+    }
+}

--- a/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/SwitchEditorCommand.java
+++ b/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/SwitchEditorCommand.java
@@ -27,7 +27,7 @@ public class SwitchEditorCommand extends AbstractWindowCommand {
         IWorkbenchPartSite editorSite = getEditorSite();
         EPartService psvc = (EPartService) editorSite.getService(EPartService.class);
         MPartStack stack = findAdjacentStack(editorSite, direction);
-        if (stack != null) {
+        if (stack != null && stack.getSelectedElement() instanceof MPart) {
             psvc.activate((MPart) stack.getSelectedElement(), true);
         }
     }

--- a/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/SwitchOtherEditorCommand.java
+++ b/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/commands/SwitchOtherEditorCommand.java
@@ -1,0 +1,48 @@
+package net.sourceforge.vrapper.plugin.splitEditor.commands;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+
+import org.eclipse.e4.ui.model.application.ui.MElementContainer;
+import org.eclipse.e4.ui.model.application.ui.MUIElement;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.e4.ui.workbench.modeling.EPartService;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.internal.WorkbenchPage;
+
+// Eclipse 4 API version 0.10.1 bundled with Eclipse 4.2.1 is considered provisional.
+@SuppressWarnings("restriction")
+/**
+ * Activates the most recently active editor in another split.
+ */
+public class SwitchOtherEditorCommand extends AbstractWindowCommand {
+    public static final SwitchOtherEditorCommand INSTANCE = new SwitchOtherEditorCommand();
+
+    @Override
+    public void execute(EditorAdaptor editorAdaptor)
+            throws CommandExecutionException {
+        final IWorkbenchPartSite editorSite = getEditorSite();
+        final WorkbenchPage page = (WorkbenchPage) editorSite.getPage();
+        final EPartService psvc = (EPartService) editorSite.getService(EPartService.class);
+        MPart activePart = (MPart) editorSite.getService(MPart.class);
+        MElementContainer<MUIElement> editorStack = activePart.getParent();
+
+        IEditorReference[] sortedEditors = page.getSortedEditors();
+        //
+        // Find most recently activated editor in a different part stack.
+        //
+        for (IEditorReference otherEditor : sortedEditors) {
+            IWorkbenchPart wbPart = otherEditor.getPart(true);
+            if (wbPart != null) {
+                MPart p = (MPart) wbPart.getSite().getService(MPart.class);
+                if (p.getParent() != editorStack) {
+                    psvc.activate(p, true);
+                    break;
+                }
+            }
+        }
+    }
+
+}

--- a/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/provider/WindowCmdStateProvider.java
+++ b/net.sourceforge.vrapper.plugin.splitEditor.eclipse/src/net/sourceforge/vrapper/plugin/splitEditor/provider/WindowCmdStateProvider.java
@@ -12,11 +12,13 @@ import net.sourceforge.vrapper.keymap.SpecialKey;
 import net.sourceforge.vrapper.keymap.State;
 import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.MoveEditorCommand;
+import net.sourceforge.vrapper.plugin.splitEditor.commands.RemoveOtherWindowsCommand;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitContainer;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitDirection;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitEditorCommand;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.SplitMode;
 import net.sourceforge.vrapper.plugin.splitEditor.commands.SwitchEditorCommand;
+import net.sourceforge.vrapper.plugin.splitEditor.commands.SwitchOtherEditorCommand;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
@@ -48,6 +50,8 @@ public class WindowCmdStateProvider extends AbstractEclipseSpecificStateProvider
             case 'L': cmd = bang ? MoveEditorCommand.CLONE_RIGHT : MoveEditorCommand.MOVE_RIGHT; break;
             case 'K': cmd = bang ? MoveEditorCommand.CLONE_UP    : MoveEditorCommand.MOVE_UP; break;
             case 'J': cmd = bang ? MoveEditorCommand.CLONE_DOWN  : MoveEditorCommand.MOVE_DOWN; break;
+            case 'o': cmd = bang ? RemoveOtherWindowsCommand.REMOVE_CLOSE  : RemoveOtherWindowsCommand.REMOVE_JOIN; break;
+            case 'w': cmd = SwitchOtherEditorCommand.INSTANCE; break;
             }
             if (cmd != null) {
                 try {
@@ -109,6 +113,9 @@ public class WindowCmdStateProvider extends AbstractEclipseSpecificStateProvider
     protected State<Command> normalModeBindings() {
         final Command vsplit = SplitEditorCommand.VSPLIT;
         final Command split = SplitEditorCommand.HSPLIT;
+        final Command removeOther = RemoveOtherWindowsCommand.REMOVE_JOIN;
+        final Command switchOther = SwitchOtherEditorCommand.INSTANCE;
+
         final Command switchEditorLeft = SwitchEditorCommand.SWITCH_LEFT;
         final Command switchEditorRight = SwitchEditorCommand.SWITCH_RIGHT;
         final Command switchEditorDown = SwitchEditorCommand.SWITCH_DOWN;
@@ -118,6 +125,7 @@ public class WindowCmdStateProvider extends AbstractEclipseSpecificStateProvider
         final Command cloneEditorRight = MoveEditorCommand.CLONE_RIGHT;
         final Command cloneEditorDown = MoveEditorCommand.CLONE_DOWN;
         final Command cloneEditorUp = MoveEditorCommand.CLONE_UP;
+
         return state(transitionBind(
                 ctrlKey('w'),
                   state(
@@ -142,6 +150,10 @@ public class WindowCmdStateProvider extends AbstractEclipseSpecificStateProvider
                         leafBind('L', MoveEditorCommand.MOVE_RIGHT),
                         leafBind('J', MoveEditorCommand.MOVE_DOWN),
                         leafBind('K', MoveEditorCommand.MOVE_UP),
+                        leafBind('w', switchOther),
+                        leafBind(ctrlKey('w'), switchOther),
+                        leafBind('o', removeOther),
+                        leafBind(ctrlKey('o'), removeOther),
                         transitionBind(
                                 'c',
                                 leafBind('h', cloneEditorLeft),


### PR DESCRIPTION
Added the following command and key mappings:
- `:wincmd[!] o` to remove all splits by either moving all editors into
  the current split or (with `!`) closing other editors. Mapped to `C-W o`
  and `C-W C-O`.
- `:wincmd w` to switch to most recently active split. The behaviour is
  different to VIM: in VIM `C-W C-W` cycles through all the splits
  moving down/right. To implement that would require editor coordinates
  which is not trivial to obtain.
