### PR TITLE
Implemented global position marks (A-Z and 0-9).

### DIFF
--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -1,5 +1,8 @@
 package net.sourceforge.vrapper.eclipse.activator;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
 import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptorManager;
 import net.sourceforge.vrapper.log.Log;
@@ -58,15 +61,26 @@ public class VrapperPlugin extends AbstractUIPlugin implements IStartup, Log {
 
 	private static MouseButtonListener mouseButton = new MouseButtonListener();
 
+    private static final Map<IEditorPart, EditorAdaptor> editorMap =
+            new HashMap<IEditorPart, EditorAdaptor>();
     /**
      * The constructor
      */
     public VrapperPlugin() {
     }
 
-    public void registerEditor(IEditorPart part) { }
+    public void registerEditor(IEditorPart part, EditorAdaptor editorAdaptor) {
+        editorMap.put(part, editorAdaptor);
+    }
+    
+    public EditorAdaptor findEditor(IEditorPart part)
+    {
+        return editorMap.get(part);
+    }
 
-    public void unregisterEditor(IEditorPart part) { }
+    public void unregisterEditor(IEditorPart part) {
+        editorMap.remove(part);
+    }
 
     @Override
     public void start(BundleContext context) throws Exception {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/GoToMarkCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/GoToMarkCommand.java
@@ -1,0 +1,119 @@
+package net.sourceforge.vrapper.eclipse.commands;
+
+import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
+import net.sourceforge.vrapper.eclipse.platform.EclipseCursorAndSelection;
+import net.sourceforge.vrapper.keymap.KeyStroke;
+import net.sourceforge.vrapper.utils.Function;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.CountIgnoringNonRepeatableCommand;
+import net.sourceforge.vrapper.vim.commands.motions.GoToMarkMotion;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+
+public class GoToMarkCommand extends CountIgnoringNonRepeatableCommand {
+
+    public enum Mode {
+        LINEWISE,
+        CHARWISE,
+        EDITOR
+    }
+
+    public static final Function<Command, KeyStroke> LINEWISE_CONVERTER = new Function<Command, KeyStroke>() {
+        public Command call(KeyStroke arg) {
+            return new GoToMarkCommand(Mode.LINEWISE, String.valueOf(arg.getCharacter()));
+        }
+    };
+
+    public static final Function<Command, KeyStroke> CHARWISE_CONVERTER = new Function<Command, KeyStroke>() {
+        public Command call(KeyStroke arg) {
+            return new GoToMarkCommand(Mode.CHARWISE, String.valueOf(arg.getCharacter()));
+        }
+    };
+
+    public static final Function<Command, KeyStroke> EDITOR_CONVERTER = new Function<Command, KeyStroke>() {
+        public Command call(KeyStroke arg) {
+            return new GoToMarkCommand(Mode.EDITOR, String.valueOf(arg.getCharacter()));
+        }
+    };
+
+    private final String id;
+    private final Mode mode;
+
+	private GoToMarkCommand(Mode mode, String id) {
+	    if (mode == Mode.EDITOR) {
+	        this.id = id.toUpperCase();
+	    } else {
+	        this.id = id;
+	    }
+	    this.mode =  mode;
+	}
+
+	public void execute(EditorAdaptor editorAdaptor)
+			throws CommandExecutionException {
+	    //
+	    // Check if there is an open editor associated with the mark.
+	    //
+        IEditorPart editor = EclipseCursorAndSelection.getGlobalMarkEditor(id);
+        if (editor == null) {
+            //
+            // Try to open the file from the mark resource.
+            //
+            IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+            IMarker marker = EclipseCursorAndSelection.getGlobalMarker(id, root);
+            if (marker != null) {
+
+                final String resourePath = marker.getResource().getProjectRelativePath().toString();
+                editorAdaptor.getFileService().openFile(resourePath);
+                //
+                // See if the mark is still in the editor after opening it.
+                //
+                editor = EclipseCursorAndSelection.getGlobalMarkEditor(id);
+                if (editor == null) {
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
+        //
+        // Activate the editor associated with the global mark.
+        //
+        final IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+        page.activate(editor);
+        //
+        // Lookup Vrapper's EditorAdapter associated with the Eclipse editor.
+        //
+        final EditorAdaptor markEditor = VrapperPlugin.getDefault().findEditor(editor);
+        if (markEditor == null) {
+            return;
+        }
+        //
+        // The associated editor is open and active, change current position
+        // if requested.
+        //
+        Position markPos = null;
+        switch (mode) {
+        case LINEWISE:
+            markPos = new GoToMarkMotion(true, id).destination(markEditor);
+            break;
+        case CHARWISE:
+            markPos = new GoToMarkMotion(false, id).destination(markEditor);
+            break;
+        case EDITOR:
+            // Don't change current position.
+            break;
+        }
+        if (markPos != null) {
+            markEditor.getCursorService().setPosition(markPos, true);
+        }
+	}
+
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptorManager.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptorManager.java
@@ -104,7 +104,7 @@ public class InputInterceptorManager implements IPartListener {
 				((ITextViewer) textViewer).getSelectionProvider()
 						.addSelectionChangedListener(interceptor);
                 interceptors.put(editor, interceptor);
-                VrapperPlugin.getDefault().registerEditor(editor);
+                VrapperPlugin.getDefault().registerEditor(editor, interceptor.getEditorAdaptor());
             }
         } catch (Exception exception) {
             VrapperLog.error("Exception when intercepting AbstractTextEditor",

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
@@ -1,5 +1,6 @@
 package net.sourceforge.vrapper.eclipse.keymap;
 
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.convertKeyStroke;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafBind;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafCtrlBind;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.operatorCmds;
@@ -10,11 +11,12 @@ import static net.sourceforge.vrapper.vim.commands.ConstructorWrappers.dontRepea
 import static net.sourceforge.vrapper.vim.commands.ConstructorWrappers.seq;
 import net.sourceforge.vrapper.eclipse.commands.ChangeTabCommand;
 import net.sourceforge.vrapper.eclipse.commands.EclipseShiftOperation;
-import net.sourceforge.vrapper.eclipse.commands.EclipseVisualMotionCommand;
+import net.sourceforge.vrapper.eclipse.commands.GoToMarkCommand;
 import net.sourceforge.vrapper.eclipse.commands.TabNewCommand;
 import net.sourceforge.vrapper.eclipse.commands.ToggleFoldingCommand;
 import net.sourceforge.vrapper.keymap.State;
 import net.sourceforge.vrapper.keymap.StateUtils;
+import net.sourceforge.vrapper.vim.VimConstants;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.DeselectAllCommand;
 import net.sourceforge.vrapper.vim.commands.LeaveVisualModeCommand;
@@ -98,7 +100,16 @@ public class EclipseSpecificStateProvider extends AbstractEclipseSpecificStatePr
                 leafCtrlBind('y', dontRepeat(editText("scroll.lineUp"))),
                 leafCtrlBind('e', dontRepeat(editText("scroll.lineDown"))),
                 leafCtrlBind('i', dontRepeat(cmd("org.eclipse.ui.navigate.forwardHistory"))),
-                leafCtrlBind('o', dontRepeat(cmd("org.eclipse.ui.navigate.backwardHistory")))),
+                leafCtrlBind('o', dontRepeat(cmd("org.eclipse.ui.navigate.backwardHistory"))),
+                transitionBind('\\', convertKeyStroke(
+                        GoToMarkCommand.EDITOR_CONVERTER,
+                        VimConstants.PRINTABLE_KEYSTROKES)),
+                transitionBind('\'', convertKeyStroke(
+                        GoToMarkCommand.LINEWISE_CONVERTER,
+                        VimConstants.PRINTABLE_KEYSTROKES)),
+                transitionBind('`', convertKeyStroke(
+                        GoToMarkCommand.CHARWISE_CONVERTER,
+                        VimConstants.PRINTABLE_KEYSTROKES))),
             prefixedOperatorCmds('g', 'u', seq(editText("lowerCase"), DeselectAllCommand.INSTANCE), textObjects),
             prefixedOperatorCmds('g', 'U', seq(editText("upperCase"), DeselectAllCommand.INSTANCE), textObjects),
             operatorCmds('>', EclipseShiftOperation.Normal.RIGHT, textObjects),

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -22,10 +22,17 @@ import net.sourceforge.vrapper.vim.commands.BlockWiseSelection.Rect;
 import net.sourceforge.vrapper.vim.commands.Selection;
 import net.sourceforge.vrapper.vim.commands.SimpleSelection;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.ITextViewerExtension5;
+import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.swt.custom.CaretEvent;
 import org.eclipse.swt.custom.CaretListener;
 import org.eclipse.swt.custom.StyledText;
@@ -34,10 +41,22 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Caret;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.WorkbenchPage;
+import org.eclipse.ui.texteditor.AbstractMarkerAnnotationModel;
+import org.eclipse.ui.texteditor.AbstractTextEditor;
+import org.eclipse.ui.texteditor.MarkerUtilities;
 
+@SuppressWarnings("restriction")
 public class EclipseCursorAndSelection implements CursorService, SelectionService {
 
     public static final String POSITION_CATEGORY_NAME = "net.sourceforge.vrapper.position";
+    /// Marker type for global (A-Z0-9) marks. Use IMarker.MARKER to make them invisible.
+    public static final String GLOBAL_MARK_TYPE = IMarker.BOOKMARK;
     private final ITextViewer textViewer;
     private int stickyColumn;
     private boolean stickToEOL = false;
@@ -310,6 +329,10 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
     @Override
     public void setMark(final String id, final Position position) {
+        if (isGlobalMark(id)) {
+            setGlobalMark(id, position);
+            return;
+        }
         final org.eclipse.jface.text.Position p = new org.eclipse.jface.text.Position(position.getModelOffset());
         try {
         	//add listener so Position automatically updates as the document changes
@@ -338,8 +361,22 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
         marks.put(id, p);
     }
 
+    private boolean isGlobalMark(final String id) {
+        return id.length() == 1
+                && ((   id.charAt(0) >= 'A' && id.charAt(0) <= 'Z')
+                    || (id.charAt(0) >= '0' && id.charAt(0) <= '9'));
+    }
+
     @Override
     public Position getMark(String id) {
+        if (isGlobalMark(id)) {
+            IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+            IMarker marker = getGlobalMarker(id, root);
+            // Check if marker is in the current file.
+            if (marker != null) {
+                return getGlobalMarkerPosition(marker);
+            }
+        }
     	//`` and '' are the same position, so we need to return that position
     	//regardless of which way the user accessed it
     	if(id.equals("`")) {
@@ -354,6 +391,105 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
         }
         final int offset = p.getOffset();
         return newPositionForModelOffset(offset);
+    }
+
+    /**
+     * Lookup the specified marker recursively starting at @a resource.
+     * Use @a ResourcesPlugin.getWorkspace().getRoot() to find the marker globally.
+     * @param id marker name
+     * @param resource resource node.
+     * @return marker or @a null if not found.
+     */
+    static public IMarker getGlobalMarker(String id, IResource resource) {
+        try {
+            final IMarker[] markers = resource.findMarkers(GLOBAL_MARK_TYPE, true, IResource.DEPTH_INFINITE);
+            for (final IMarker m: markers) {
+                if (m.getAttribute(IMarker.MESSAGE, "--").equals(id)) {
+                    return m;
+                }
+            }
+        } catch (CoreException e) {
+            // Ignore.
+        }
+        return null;
+    }
+
+    /**
+     * Creates a global bookmark for the specified position.
+     * @param name bookmark name
+     * @param position editor position for the bookmark.
+     */
+    public void setGlobalMark(String name, Position position) {
+        final IEditorPart editorPart =
+                PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+        if (editorPart != null) {
+            final IFileEditorInput input = (IFileEditorInput)editorPart.getEditorInput();
+            final IFile file = input.getFile();
+            final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+            try {
+                final IMarker marker = getGlobalMarker(name, root);
+                if (marker != null) {
+                    marker.delete();
+                }
+                final HashMap<String, Object> map = new HashMap<String, Object>();
+                MarkerUtilities.setMessage(map, name);
+                final int line = textViewer.getDocument().getLineOfOffset(position.getModelOffset());
+                MarkerUtilities.setLineNumber(map, line);
+                MarkerUtilities.setCharStart(map, position.getModelOffset());
+                MarkerUtilities.setCharEnd(map, position.getModelOffset() + 1);
+                MarkerUtilities.createMarker(file, map, GLOBAL_MARK_TYPE);
+            } catch (Exception e) {
+                VrapperLog.error("could not set global mark", e);
+            }
+        }
+    }
+
+    /**
+     * Finds an editor associated with the specified mark.
+     * @param name mark name
+     * @return IEditorPart or null if not found.
+     */
+    static public IEditorPart getGlobalMarkEditor(String name) {
+        final WorkbenchPage page = (WorkbenchPage) PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+        final IEditorReference[] editorReferences = page.getSortedEditors();
+        for (final IEditorReference e : editorReferences) {
+            try {
+                final IFileEditorInput input = (IFileEditorInput)e.getEditorInput();
+                if (getGlobalMarker(name, input.getFile()) != null) {
+                    return (IEditorPart) e.getPart(true);
+                }
+            } catch (PartInitException e1) {
+            }
+        }
+        return null;
+    }
+
+    private Position getGlobalMarkerPosition(IMarker marker) {
+        int start = MarkerUtilities.getCharStart(marker);
+        final IEditorPart editorPart =
+                PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+
+        if (editorPart != null) {
+            final IFileEditorInput input = (IFileEditorInput)editorPart.getEditorInput();
+            if (editorPart instanceof AbstractTextEditor) {
+                final AbstractTextEditor editor = (AbstractTextEditor) editorPart;
+                final IAnnotationModel annotationModel = editor.getDocumentProvider().getAnnotationModel(input);
+                if (annotationModel instanceof AbstractMarkerAnnotationModel) {
+                    final AbstractMarkerAnnotationModel markerModel= (AbstractMarkerAnnotationModel) annotationModel;
+                    final org.eclipse.jface.text.Position pos = markerModel.getMarkerPosition(marker);
+                    if (pos != null && !pos.isDeleted()) {
+                        // Use the position instead of marker offset.
+                        start = pos.getOffset();
+                    } else {
+                        // Do nothing if the position has been deleted or the
+                        // marker is not in the current file.
+                        return null;
+                    }
+                }
+
+            }
+        }
+        return newPositionForModelOffset(start);
     }
 
     @Override


### PR DESCRIPTION
If capital or digit mark name is used with `m{A-Z0-9}` the mark is
considered global in VIM. So that goto mark operation will switch the
current buffer if necessary. Current implementation uses Eclipse
bookmarks for this feature which make global marks visible, manageable
and persistent across restarts.

In addition to existing goto mark operations `\{a-zA-Z0-9}` was added to
switch to the editor associated with the mark without changing current
position. Thus allowing for editor bookmarks, not position bookmark.
**WARNING**: might conflict with user mappings of `\`.
