### PR TITLE
Fix current position in visual mode.

### DIFF
--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -88,7 +88,13 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
     @Override
     public Position getPosition() {
-        return new TextViewerPosition(textViewer, Space.VIEW, textViewer.getTextWidget().getCaretOffset());
+    	Point sel = textViewer.getSelectedRange();
+    	int carretOffset = textViewer.getTextWidget().getCaretOffset();
+    	int cursorPos = converter.widgetOffset2ModelOffset(carretOffset);
+    	if (sel.y > 0 && cursorPos == sel.x + sel.y) {
+    		--cursorPos;
+    	}
+    	return new TextViewerPosition(textViewer, Space.MODEL, cursorPos);
     }
 
     @Override


### PR DESCRIPTION
Adjusts current position in visual mode to point to the last selected
character, not the next one.
This fixes issues like:

```
          cursror
          |
 text worda wordb
          ~
          ^selection
```

Before the fix if `iw` is pressed both words will be selected:

```
                cursror
                |
 text worda wordb
      ~~~~~~~~~~~
      ^selection
```

With this fix:

```
          cursror
          |
 text worda wordb
      ~~~~~
      ^selection
```

This also applies to other motions that depend on the current position.
