### PR TITLE
Avoid unnecessary caret shape reset.

### DIFF
--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -69,6 +69,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
     private final Configuration configuration;
     private final EclipseTextContent textContent;
     private int averageCharWidth;
+    private CaretType caretType = null;
 
 	public EclipseCursorAndSelection(final Configuration configuration,
 			final ITextViewer textViewer, final EclipseTextContent textContent) {
@@ -269,11 +270,14 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
     @Override
     public void setCaret(final CaretType caretType) {
-        final StyledText styledText = textViewer.getTextWidget();
-        final Caret old = styledText.getCaret();
-        styledText.setCaret(CaretUtils.createCaret(caretType, styledText));
-        // old caret is not disposed automatically
-        old.dispose();
+        if (this.caretType != caretType) {
+            final StyledText styledText = textViewer.getTextWidget();
+            final Caret old = styledText.getCaret();
+            styledText.setCaret(CaretUtils.createCaret(caretType, styledText));
+            // old caret is not disposed automatically
+            old.dispose();
+            this.caretType = caretType;
+        }
     }
 
     @Override


### PR DESCRIPTION
`setCaret()` seems quite expensive and is called for every keystroke in the normal mode.
With this change my Eclipse "feels" less sluggish. I've spend a day with the change and didn't notice the caret being in a wrong shape.
