### PR TITLE
Fix off-by-one error for reversed UI-selection

### DIFF
--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -198,8 +198,10 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
         final int len = sel.y;
         if (len > 0) {
             final int pos = converter.widgetOffset2ModelOffset(textViewer.getTextWidget().getCaretOffset());
-            if (start == pos) {
-                start += len+1;
+            if (sel.x == pos) {
+                //sel.x is left bound of UI selection and cursor is to the left,
+                //so start of the selection should be moved to the right (reversed selection).
+                start += len;
             } else {
                 end += len;
             }


### PR DESCRIPTION
This is a further improvement on #253 where the selection would be non-empty due to an seemingly unnecessary `+ 1`. I want to remove this addition to make sure that a reversed selection isn't suddenly one character longer than intended, deleting more than wanted for the feature requested in #249.

This addition _might_ have been necessary at one point, but this seems no longer the case. The visual modes have been completely overhauled since that tiny piece of code was written, and so it's likely that it was simply forgotten about.

I've been testing this one for a while but I couldn't find any problems so far...
