### PR TITLE
Fix 309

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -133,11 +133,13 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
 
         fileService = editor.getFileService();
         __set_modes(this);
-        readConfiguration();
         setNewLineFromFirstLine();
         if (isActive) {
             changeModeSafely(NormalMode.NAME);
         }
+        // NOTE: Read the config _after_ changing mode to allow default keys
+        //       remapping.
+        readConfiguration();
     }
 
     public String getLastModeName() {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseMoveCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseMoveCommand.java
@@ -29,7 +29,7 @@ public class EclipseMoveCommand extends CountAwareMotion {
     @Override
     public Position destination(EditorAdaptor editorAdaptor, int count) {
         Position oldCarretOffset = editorAdaptor.getPosition();
-        EclipseCommand.doIt(count, motionName, editorAdaptor);
+        EclipseCommand.doIt(count, motionName, editorAdaptor, false);
         Position newCarretOffset = editorAdaptor.getPosition();
         editorAdaptor.setPosition(oldCarretOffset, StickyColumnPolicy.ON_CHANGE);
         return newCarretOffset;

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseShiftOperation.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseShiftOperation.java
@@ -62,7 +62,7 @@ public abstract class EclipseShiftOperation implements TextOperation {
             
             for (int i = 0; i < count; i++) {
                 editorAdaptor.setSelection(createSelection(editorAdaptor, startLine, endLine));
-                EclipseCommand.doIt(1, action, editorAdaptor);
+                EclipseCommand.doIt(1, action, editorAdaptor, false);
             }
             editorAdaptor.setPosition(
                     editorAdaptor.getCursorService().newPositionForModelOffset(

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/TabNewCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/TabNewCommand.java
@@ -32,6 +32,6 @@ public class TabNewCommand extends EclipseCommand {
     }
     
     public void execute(EditorAdaptor editorAdaptor) {
-        doIt(1, getCommandName(), editorAdaptor);
+        doIt(1, getCommandName(), editorAdaptor, true);
     }
 }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/ToggleFoldingCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/ToggleFoldingCommand.java
@@ -17,10 +17,10 @@ public class ToggleFoldingCommand extends CountIgnoringNonRepeatableCommand {
 	public void execute(EditorAdaptor editorAdaptor)
 			throws CommandExecutionException {
 		int before = editorAdaptor.getViewContent().getNumberOfLines();
-		EclipseCommand.doIt(Command.NO_COUNT_GIVEN, EXPAND, editorAdaptor);
+		EclipseCommand.doIt(Command.NO_COUNT_GIVEN, EXPAND, editorAdaptor, false);
 		int after = editorAdaptor.getViewContent().getNumberOfLines();
 		if (before == after) {
-			EclipseCommand.doIt(Command.NO_COUNT_GIVEN, COLLAPSE, editorAdaptor);
+			EclipseCommand.doIt(Command.NO_COUNT_GIVEN, COLLAPSE, editorAdaptor, false);
 		}
 	}
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/AbstractEclipseSpecificStateProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/AbstractEclipseSpecificStateProvider.java
@@ -89,10 +89,12 @@ public class AbstractEclipseSpecificStateProvider implements
     protected static class EclipseActionEvaluator implements Evaluator {
 
         private boolean force;
+        private boolean async;
 
-        protected EclipseActionEvaluator(boolean force) {
+        protected EclipseActionEvaluator(boolean force, boolean async) {
             super();
             this.force = force;
+            this.async = async;
         }
 
         public Object evaluate(EditorAdaptor vim, Queue<String> command) {
@@ -107,7 +109,7 @@ public class AbstractEclipseSpecificStateProvider implements
             if (name != null && action != null) {
                 CommandLineMode mode = (CommandLineMode) vim
                         .getMode(CommandLineMode.NAME);
-                mode.addCommand(name, new EclipseCommand(action), force);
+                mode.addCommand(name, new EclipseCommand(action, async), force);
             }
             return null;
         }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
@@ -35,8 +35,10 @@ public class EclipseSpecificStateProvider extends AbstractEclipseSpecificStatePr
 
     // Loaded on Eclipse start
     public EclipseSpecificStateProvider() {
-        commands.add("eclipseaction", new EclipseActionEvaluator(false));
-        commands.add("eclipseaction!", new EclipseActionEvaluator(true));
+        commands.add("eclipseaction", new EclipseActionEvaluator(false, false));
+        commands.add("eclipseaction!", new EclipseActionEvaluator(true, false));
+        commands.add("eclipseuiaction", new EclipseActionEvaluator(false, true));
+        commands.add("eclipseuiaction!", new EclipseActionEvaluator(true, true));
 
     	commands.add("ls",          dontRepeat(cmd("org.eclipse.ui.window.openEditorDropDown")));
     	commands.add("buffers",     dontRepeat(cmd("org.eclipse.ui.window.openEditorDropDown")));


### PR DESCRIPTION
This adds a special kind of `eclipseaction`s that run asynchronously through a new command named `eclipseuiaction`.
This enables a few interesting commands:

```
eclipseuiaction eclipsegotoimpl org.eclipse.jdt.ui.edit.text.java.open.implementation
eclipseuiaction quickdiff org.eclipse.ui.edit.text.showChangeRulerInformation
eclipseuiaction showtooltip org.eclipse.ui.edit.text.showInformation
eclipseuiaction ctx org.eclipse.ui.activeContextInfo
eclipseuiaction rulerctx org.eclipse.ui.edit.text.showRulerContextMenu
```
