### PR TITLE
Work on #336: use polymorphic getRegion() to support inner and outer cases.

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/DelimitedTextObject.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/DelimitedTextObject.java
@@ -21,8 +21,9 @@ public abstract class DelimitedTextObject extends AbstractTextObject {
         int currentOffset = currentPosition.getModelOffset();
         TextRange leftDelimiter = delimitedText.leftDelimiter(currentOffset, editorAdaptor, count);
         TextRange rightDelimiter = delimitedText.rightDelimiter(currentOffset, editorAdaptor, count);
-        final Position leftBound = leftDelimiter.getLeftBound();
-        final Position rightBound = rightDelimiter.getRightBound();
+        final TextRange newRegion = getRegion(leftDelimiter, rightDelimiter);
+        final Position leftBound = newRegion.getLeftBound();
+        final Position rightBound = newRegion.getRightBound();
         /* 
          * From VIM's search.c:
          * In Visual mode, when the resulting area is not bigger than what we
@@ -34,8 +35,10 @@ public abstract class DelimitedTextObject extends AbstractTextObject {
                 leftOffset > 0 &&
                 rightOffset <= currentSelection.getRightBound().getModelOffset() &&
                 rightOffset < editorAdaptor.getModelContent().getTextLength()) {
-            leftDelimiter = delimitedText.leftDelimiter(leftOffset - 1, editorAdaptor, count);
-            rightDelimiter = delimitedText.rightDelimiter(rightOffset, editorAdaptor, count);
+            final int nextLeftOffset  = leftDelimiter.getLeftBound().getModelOffset() - 1;
+            final int nextRightOffset = rightDelimiter.getRightBound().getModelOffset();
+            leftDelimiter = delimitedText.leftDelimiter(nextLeftOffset, editorAdaptor, count);
+            rightDelimiter = delimitedText.rightDelimiter(nextRightOffset, editorAdaptor, count);
         }
         return getRegion(leftDelimiter, rightDelimiter);
     }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SelectTextObjectCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SelectTextObjectCommand.java
@@ -10,9 +10,6 @@ import net.sourceforge.vrapper.vim.modes.VisualMode;
 public class SelectTextObjectCommand extends CountAwareCommand {
 
     private final TextObject textObject;
-    //each selection is a new instance, have to make this static
-    //to persist between invocations
-    private static int chainingCount = 0;
 
     public SelectTextObjectCommand(final TextObject textObject) {
         this.textObject = textObject;
@@ -20,41 +17,7 @@ public class SelectTextObjectCommand extends CountAwareCommand {
 
     @Override
     public void execute(final EditorAdaptor editorAdaptor, int count) throws CommandExecutionException {
-        Selection oldSelection = editorAdaptor.getSelection();
         TextRange region = textObject.getRegion(editorAdaptor, count);
-        //if selection was calculated to be the same as before
-        //it probably means we're chaining i{i{, expand to next region
-        if(textObject instanceof DelimitedTextObject
-                && oldSelection.getLeftBound().getModelOffset() == region.getLeftBound().getModelOffset()
-                && oldSelection.getRightBound().getModelOffset() == region.getRightBound().getModelOffset()) {
-
-            try {
-                //get region again and see if selection expands
-                //(this should work if the cursor is not on a delimiter character)
-                region = textObject.getRegion(editorAdaptor, chainingCount);
-            }
-            catch(CommandExecutionException e) {
-                chainingCount = 0;
-                region = textObject.getRegion(editorAdaptor, chainingCount);
-            }
-
-            if(oldSelection.getLeftBound().getModelOffset() == region.getLeftBound().getModelOffset()
-                    && oldSelection.getRightBound().getModelOffset() == region.getRightBound().getModelOffset()) {
-                //selection didn't change, cursor is probably on the delimiter
-                //increase the count and get region again
-                chainingCount += chainingCount == 0 ? 2 : 1;
-                region = textObject.getRegion(editorAdaptor, chainingCount);
-            }
-            else {
-                //cursor is not on a delimiter anymore
-                chainingCount = 0;
-            }
-        }
-        else {
-            //new selection, reset chaining
-            chainingCount = 0;
-        }
-
         Selection selection;
         String newMode;
         switch (textObject.getContentType(editorAdaptor.getConfiguration())) {


### PR DESCRIPTION
This improves on the idea I used to implement extension of `a(`, `a{`.
It still has an off-by-one issue if brackets are next to each other,
but works in general cases. I'm experiencing lack of time ATM to fix it 
properly. If fixing the issues proves to be tough we could add
another polymorphic method to account for inner/outer differences. 
