### PR TITLE
CommandLineParser: added support for :xa / :xall

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
@@ -235,6 +235,8 @@ public class CommandLineParser extends AbstractCommandParser {
         mapping.add("w", save);
         mapping.add("wall", saveAll);
         mapping.add("wqall", saveAndCloseAll);
+        mapping.add("xall", saveAndCloseAll);
+        mapping.add("xa", saveAndCloseAll);
     	mapping.add("update", save);
         mapping.add("wq", saveAndClose);
         mapping.add("x", saveAndClose);


### PR DESCRIPTION
Hey, Thanks for a great plugin! I love it. I just thought seeing as you already added :wqall may as well add :xa also (a bit easier on the fingers).
