### PR TITLE
Make all command definitions local

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
@@ -46,7 +46,8 @@ public class CommandLineTests extends VimTestCase {
     
     @Test
     public void testCommandLineParser() {
-    	CommandLineParser parser = new CommandLineParser(adaptor);
+    	CommandLineMode commandLineMode = new CommandLineMode(adaptor);
+    	CommandLineParser parser = commandLineMode.createParser();
     	Command command;
     	
     	command = parser.parseAndExecute(":", "set nohlsearch");

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VrapperRCTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VrapperRCTests.java
@@ -16,6 +16,7 @@ import net.sourceforge.vrapper.keymap.KeyStroke;
 import net.sourceforge.vrapper.keymap.Remapping;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
+import net.sourceforge.vrapper.vim.modes.commandline.CommandLineMode;
 import net.sourceforge.vrapper.vim.modes.commandline.CommandLineParser;
 
 import org.junit.Test;
@@ -29,7 +30,8 @@ public class VrapperRCTests extends VimTestCase {
         try {
             reader = new BufferedReader(new FileReader(config));
             String line;
-            CommandLineParser parser = new CommandLineParser(adaptor);
+            CommandLineMode commandLineMode = new CommandLineMode(adaptor);
+            CommandLineParser parser = commandLineMode.createParser();
             while((line = reader.readLine()) != null) {
                 Command c = parser.parseAndExecute(null, line.trim());
                 if (c != null) {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -222,7 +222,8 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
         	try {
         		reader = new BufferedReader(new FileReader(config));
         		String line;
-        		final CommandLineParser parser = new CommandLineParser(this);
+        		CommandLineMode cmdLineMode = (CommandLineMode) modeMap.get(CommandLineMode.NAME);
+        		final CommandLineParser parser = cmdLineMode.createParser();
         		String trimmed;
         		while((line = reader.readLine()) != null) {
         			//*** skip over everything in a .vimrc file that we don't support ***//

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/CommandLineParser.java
@@ -56,10 +56,10 @@ import net.sourceforge.vrapper.vim.modes.VisualMode;
  */
 public class CommandLineParser extends AbstractCommandParser {
 
-    private static final EvaluatorMapping mapping;
+    private final EvaluatorMapping mapping;
     private final FilePathTabCompletion tabComplete;
 
-    static {
+    static EvaluatorMapping coreCommands() {
         Evaluator noremap = new KeyMapper.Map(false,
                 AbstractVisualMode.KEYMAP_NAME, NormalMode.KEYMAP_NAME);
         Evaluator map = new KeyMapper.Map(true,
@@ -258,7 +258,7 @@ public class CommandLineParser extends AbstractCommandParser {
             }
         };
         
-        mapping = new EvaluatorMapping();
+        EvaluatorMapping mapping = new EvaluatorMapping();
         // options
         mapping.add("set", buildConfigEvaluator(/*local=*/false));
         mapping.add("setlocal", buildConfigEvaluator(/*local=*/true));
@@ -351,6 +351,7 @@ public class CommandLineParser extends AbstractCommandParser {
     	mapping.add("registers", registers);
     	mapping.add("display", registers);
     	mapping.add("marks", marks);
+        return mapping;
     }
 
     private static Evaluator buildConfigEvaluator(boolean local) {
@@ -417,8 +418,9 @@ public class CommandLineParser extends AbstractCommandParser {
         }
     }
 
-    public CommandLineParser(EditorAdaptor vim) {
+    public CommandLineParser(EditorAdaptor vim, EvaluatorMapping commands) {
         super(vim);
+        this.mapping = commands;
         this.tabComplete = new FilePathTabCompletion(vim);
     }
 
@@ -658,12 +660,8 @@ public class CommandLineParser extends AbstractCommandParser {
     	return null;
     }
     
-    public static boolean addCommand(String commandName, Command command, boolean overwrite) {
-        if (overwrite || !mapping.contains(commandName)) {
-            mapping.add(commandName, command);
-            return true;
-        }
-        return false;
+    void addCommand(String commandName, Command command, boolean overwrite) {
+        mapping.add(commandName, command);
     }
     
     class LineRangeExCommandEvaluator implements Command {


### PR DESCRIPTION
As discussed in #382 and #327 before that by @keforbes and @igrekster.

The way `:eclipseaction` works is pushing commands into a static variable, thus creating commands for all tabs at the same time.

This pull request makes the `CommandLineMode` hold both the static core commands mappings and
a local mapping for user commands, then passing the combined mapping to the `CommandLineParser`.

It is now easier to construct a `CommandLineParser` through the `CommandLineMode`'s `createParser` function, so I inserted that into all command line tests to keep them working.
