### PR TITLE
Try different algorithm to avoid insane xml tag regex

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/XmlTagDelimitedText.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/XmlTagDelimitedText.java
@@ -1,11 +1,9 @@
 package net.sourceforge.vrapper.vim.commands;
 
-import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.sourceforge.vrapper.platform.TextContent;
-import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.utils.StartEndTextRange;
 import net.sourceforge.vrapper.utils.TextRange;
@@ -19,331 +17,99 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
  * This aligns with how Vim handles things.
  */
 public class XmlTagDelimitedText implements DelimitedText {
-    
-    //regex usually stops at newlines but open tags might have
-    //multiple lines of attributes.  So, include newlines in search.
-	//Skip comments (<!-- foo -->), empty-element tags (<foo/>), and jsp (<% %>)
-    private static final String XML_TAG_REGEX = "<(?:(?!%|!))[^<]*?(?:(?<!%|/))>";
-    private static final Pattern tagPattern = Pattern.compile(XML_TAG_REGEX, Pattern.DOTALL);
-    
-    private static final String XML_NAME_REGEX = "</?([^\\s]*).*?>";
-    private static final Pattern tagNamePattern = Pattern.compile(XML_NAME_REGEX, Pattern.DOTALL);
-    
-    private TextRange endTag;
-    private TextRange openTag;
-	
+    /**
+     * Look for close tag first. Easier regex pattern to find and get the tag name.
+     * If valid tag name found, then search backwards for matching opening tag.
+     */
+    private static final String XML_CLOSE_TAG_REGEX = "<\\/([a-zA-Z]\\w*(?:\\:?[a-zA-Z]\\w*)(?:[^>])*)>";
+    private static final Pattern closeTagPattern = Pattern.compile(XML_CLOSE_TAG_REGEX);
+
+    private static final String XML_TAG_ATTR_REGEX = "(?:(?:\\s*<%.*?%>\\s*)|(?:\\s*\\w=\"[^\"]+\"\\s*))*>";
+    private static final Pattern tagAttrPattern = Pattern.compile(XML_TAG_ATTR_REGEX);
+
+    private TextRange openTag = null;
+    private TextRange closeTag = null;
+
     @Override
-    public TextRange leftDelimiter(int offset, EditorAdaptor editorAdaptor,
-            int count) throws CommandExecutionException {
-    	calculateOpenAndCloseTag(offset, editorAdaptor, count);
+    public TextRange leftDelimiter(int offset, EditorAdaptor editorAdaptor, int count) throws CommandExecutionException {
+        if (openTag == null) {
+            calculateOpenAndCloseTag(offset, editorAdaptor, count);
+        }
         return openTag;
     }
 
     @Override
-    public TextRange rightDelimiter(int offset, EditorAdaptor editorAdaptor,
-            int count) throws CommandExecutionException {
-        calculateOpenAndCloseTag(offset, editorAdaptor, count);
-        return endTag;
+    public TextRange rightDelimiter(int offset, EditorAdaptor editorAdaptor, int count) throws CommandExecutionException {
+        if (closeTag == null) {
+            calculateOpenAndCloseTag(offset, editorAdaptor, count);
+        }
+        return closeTag;
     }
-    
+
     private void calculateOpenAndCloseTag(int offset, EditorAdaptor editorAdaptor, int count) throws CommandExecutionException {
-        if(count == 0) {
-    		count = 1;
-    	}
-    	
-    	Position beginningPosition = getStartingPosition(offset, editorAdaptor);
-    	
-    	Position startOpenSearch = beginningPosition.addModelOffset(1);
-    	Position startCloseSearch = beginningPosition.addModelOffset(-1);
+        openTag = closeTag = null;
 
-    	for(int i=0; i < count; i++) {
-    		//Vim first looks left for an opening tag to determine what close tag to look for
-    		openTag = getUnbalancedOpenTag(startOpenSearch, editorAdaptor);
-    		String tagName = getTagName(openTag, editorAdaptor);
-    		
-    		//find the first unbalanced closing tag after start
-    		//that matches the name of the opening tag we found
-    		endTag = getUnbalancedClosingTag(startCloseSearch, tagName, editorAdaptor);
-    		
-    		//prepare for next iteration (if any)
-    		//to find the parent open and closing tags to the ones we just found
-    		startOpenSearch = openTag.getLeftBound();
-    		startCloseSearch = endTag.getRightBound();
-    	}
-    }
-
-    /**
-     * Account for the possibility that we're in front of a tag (indentation) or inside an opening or closing tag.
-     * @throws CommandExecutionException 
-     */
-    private Position getStartingPosition(int offset, EditorAdaptor editorAdaptor) throws CommandExecutionException {
         Position beginningPosition = editorAdaptor.getCursorService().newPositionForModelOffset(offset);
+    	Position startOpenSearch = beginningPosition.addModelOffset(1);
 
-        if (insideIndentation(beginningPosition, editorAdaptor)) {
-            // we are in the indentation at the start of a line, move to tags on the right.
-            TextRange tag = findNextTag(beginningPosition, editorAdaptor);
-            String contents = editorAdaptor.getModelContent().getText(tag);
-            if (isCloseTag(contents)) {
-                beginningPosition = tag.getLeftBound();
-            } else {
-                beginningPosition = tag.getRightBound();
-            }
-        } else {
-            
-            if (insideOpeningTag(beginningPosition, editorAdaptor)) {
-                //move to the end of the opening tag we're inside
-                while (characterAt(beginningPosition,editorAdaptor) != '>') {
-                    beginningPosition = beginningPosition.addModelOffset(1);
-                }
-            }
-            
-            if (insideClosingTag(beginningPosition, editorAdaptor)) {
-                //move to the beginning of the closing tag we're inside
-                while (characterAt(beginningPosition,editorAdaptor) != '<') {
-                    beginningPosition = beginningPosition.addModelOffset(-1);
-                }
-            }
-        }
-    	
-        return beginningPosition;
-    }
-    
-    private boolean insideIndentation(Position position, EditorAdaptor editorAdaptor) throws CommandExecutionException {
-        boolean isIndentation = false;
-        
-        if (Character.isWhitespace(characterAt(position, editorAdaptor))) {
-            LineInformation currentLine = editorAdaptor.getModelContent().getLineInformationOfOffset(
-                                        position.getModelOffset());
-            // Check if anything on this line before position is whitespace as well.
-            int column = position.getModelOffset() - currentLine.getBeginOffset();
-            String lineText = editorAdaptor.getModelContent().getText(
-                        currentLine.getBeginOffset(), currentLine.getLength());
-
-            // Check for blank line or if we are outside of line contents.
-            if (lineText.length() == 0 || column < 0 || column >= lineText.length()) {
-            	return false;
-            }
-            
-            int i = column;
-            while (i >= 0 && Character.isWhitespace(lineText.charAt(i))) {
-                i--;
-            }
-            if (i < 0) {
-                // If everything on the left is whitespace, check if this is indentation for any tag to the right.
-                TextRange nextTag = findNextTag(position, editorAdaptor);
-                int tagColumn = nextTag.getLeftBound().getModelOffset() - currentLine.getBeginOffset();
-                if (tagColumn < lineText.length()) {
-                    i = column;
-                    while (i < tagColumn && Character.isWhitespace(lineText.charAt(i))) {
-                        i++;
-                    }
-                    isIndentation = (i == tagColumn);
-                }
-            }
-        }
-        return isIndentation;
-    }
-    
-    private boolean insideOpeningTag(Position position, EditorAdaptor editorAdaptor) {
-        return insideTag(position, editorAdaptor, true);
-    }
-    
-    private boolean insideClosingTag(Position position, EditorAdaptor editorAdaptor) {
-        return insideTag(position, editorAdaptor, false);
-    }
-    
-    private boolean insideTag(Position position, EditorAdaptor editorAdaptor, boolean openingTag) {
-        return (toRightOfTagOpener(position, editorAdaptor, openingTag) && toLeftOfTagCloser(position, editorAdaptor));
-    }
-
-    private boolean toLeftOfTagCloser(Position position, EditorAdaptor editorAdaptor) {
-        while (characterAt(position, editorAdaptor) != '>') {
-           position = position.addModelOffset(1);
-           if (position.getModelOffset() >= editorAdaptor.getModelContent().getTextLength()) {
-               return false;
-           }
-           
-           if (characterAt(position, editorAdaptor) == '<') {
-               return false;
-           }
-        }
-        return true;
-    }
-
-    private boolean toRightOfTagOpener(Position position, EditorAdaptor editorAdaptor, boolean openingTag) {
-        while (characterAt(position, editorAdaptor) != '<') {
-           position = position.addModelOffset(-1);
-           if (position.getModelOffset() < 0) {
-               return false;
-           }
-           
-           if (characterAt(position, editorAdaptor) == '>') {
-               return false;
-           }
-        }
-        //check if the char after '<' is '/'
-        position = position.addModelOffset(1); 
-        if (openingTag) {
-            return characterAt(position, editorAdaptor) != '/';
-        } else {
-            return characterAt(position, editorAdaptor) == '/';
-        }
-    }
-
-    private char characterAt(Position position, EditorAdaptor editorAdaptor) {
-        return editorAdaptor.getModelContent().getText(position.getModelOffset(), 1).charAt(0);
-    }
-
-    /**
-     * Search backwards for XML tags.  Push every close tag, pop every open tag.
-     * If we get the open tag we're looking for without a matching close tag, we're inside that tag.
-     */
-    public TextRange getUnbalancedOpenTag(Position start, EditorAdaptor editorAdaptor) throws CommandExecutionException {
-    	Stack<String> closeTags = new Stack<String>();
-    	TextRange tag;
-    	String contents;
-    	String tagName;
-    	
-    	while (true) { //we'll either hit a 'return' or throw an exception
-    		tag = findPreviousTag(start, editorAdaptor);
-    		contents = editorAdaptor.getModelContent().getText(tag);
-    		start = tag.getLeftBound(); //prepare for next iteration
-    		
-    		if(isCloseTag(contents)) {
-    			tagName = getTagName(tag, editorAdaptor);
-    			closeTags.push(tagName);
-    		}
-    		else { //open tag
-    			tagName = getTagName(tag, editorAdaptor);
-    			if(closeTags.empty()) {
-    				//we hit the desired open tag before finding any close tags
-    				//the cursor must be inside this tag
-    				return tag;
-    			}
-    			else if (closeTags.peek().equals(tagName)) {
-    				//found the matching open tag for this close tag
-    				//ignore it and keep moving
-    				closeTags.pop();
-    			}
-    			else {
-    				//we found an open tag without a corresponding close tag
-    				//but it wasn't the open tag we wanted
-    				//ignore it and keep moving (this is how vim handles it)
-    			}
-    		}
-    	}
-    }
-
-    private boolean isCloseTag(String contents) {
-        return contents.startsWith("</");
-    }
-    
-    /**
-     * Search forwards for XML tags.  Push every open tag, pop every close tag.
-     * If we get a close tag without an open tag, we're inside that tag.
-     */
-    public TextRange getUnbalancedClosingTag(Position start, String toFindTagName, EditorAdaptor editorAdaptor) throws CommandExecutionException {
-    	Stack<String> openTags = new Stack<String>();
-    	TextRange tag;
-    	String contents;
-    	String tagName;
-    	
-    	while (true) { //we'll either hit a 'return' or throw an exception
-    		tag = findNextTag(start, editorAdaptor);
-    		contents = editorAdaptor.getModelContent().getText(tag);
-    		start = tag.getRightBound(); //prepare for next iteration
-
-    		if(isCloseTag(contents)) {
-    			tagName = getTagName(tag, editorAdaptor);
-    			if(tagName.equals(toFindTagName) && openTags.empty()) {
-    				//we hit a close tag before finding any open tags
-    				//the cursor must be inside this tag
-    				return tag;
-    			}
-    			else if(tagName.equals(toFindTagName)) {
-    				//found the matching close tag for this open tag
-    				//ignore it and keep moving
-    				openTags.pop();
-    			}
-    		}
-    		else { //open tag, see if we'll find it's matching close tag
-    			tagName = getTagName(tag, editorAdaptor);
-    			if (tagName.equals(toFindTagName)) {
-    			    openTags.push(tagName);
-    			}
-    		}
-    	}
-    }
-    
-    
-    /**
-     * Search for the next XML tag after start.  Can either be an open tag or
-     * close tag.  We'll let the calling method figure out what to do with it.
-     */
-    private TextRange findNextTag(Position start, EditorAdaptor editorAdaptor) throws CommandExecutionException {
         TextContent content = editorAdaptor.getModelContent();
-        int startPos = start.getModelOffset();
+        int startPos = startOpenSearch.getModelOffset();
         String textAfterStartPos = getText(editorAdaptor, startPos, content.getTextLength());
-        return rangeForFirstXmlTagWithOffset(editorAdaptor, textAfterStartPos, startPos);
+
+        // find close tag with specified 'count' iteration
+        // if no close tag found with iteration, throw CommandExecutionException
+        Matcher closeTagMatch = closeTagPattern.matcher(textAfterStartPos);
+        for (int i = 0; i < count; ++i) {
+            if (!closeTagMatch.find()) {
+                throw new CommandExecutionException("No close tag found. Count: " + count + ", i: " + i);
+            }
+        }
+
+        closeTag = getRange(editorAdaptor, closeTagMatch.start(), closeTagMatch.end());
+        String tagName = closeTagMatch.group(1);
+
+        // search backwards for a valid matching open tag
+        String textBeforeCloseTag = getText(editorAdaptor, 0, closeTagMatch.start());
+        String openTagStr = '<' + tagName;
+        int openTagLen = openTagStr.length();
+        int openTagStart = closeTagMatch.start() - 1;
+
+        while (openTagStart >= 0) {
+            openTagStart = textBeforeCloseTag.lastIndexOf(openTagStr, openTagStart);
+            int nextcIdx = openTagStart + openTagLen;
+            // ensure it's the proper open tag by inspecting next char
+            char nextc = textBeforeCloseTag.charAt(nextcIdx);
+            if (nextc == '>') {
+                // matching open tag found
+                openTag = getRange(editorAdaptor, openTagStart, openTagStart + openTagLen + 1);
+                break;
+            } else {
+                // need to scan rest of tag to ensure tag validity
+                Matcher openTagAttrMatch = tagAttrPattern.matcher(textBeforeCloseTag.substring(nextcIdx, closeTagMatch.end()));
+                if (openTagAttrMatch.find()) {
+                    // valid matching open tag found
+                    openTag = getRange(editorAdaptor, openTagStart, openTagAttrMatch.end());
+                    break;
+                }
+            }
+
+            --openTagStart;
+        }
+
+        if (openTag == null) {
+            // if no matching open tag found with iteration, throw CommandExecutionException
+            throw new CommandExecutionException("No open tag found. Count: " + count);
+        }
     }
 
-    private TextRange rangeForFirstXmlTagWithOffset(EditorAdaptor editorAdaptor, String text, int startPos) throws CommandExecutionException {
-        Matcher matcher = tagPattern.matcher(text);
-        if (matcher.find()) {
-            int matchStart = matcher.start() + startPos;
-            int matchEnd = matcher.end() + startPos;
-            return getRange(editorAdaptor, matchStart, matchEnd);
-        } else {
-            throw new CommandExecutionException("The cursor is not within an XML tag");
-        }
-    }
-    
-    /**
-     * Search for the previous XML tag before start.  Can either be an open tag or
-     * close tag.  We'll let the calling method figure out what to do with it.
-     */
-    private TextRange findPreviousTag(Position start, EditorAdaptor editorAdaptor) throws CommandExecutionException {
-        int startPos = start.getModelOffset();
-        String textBeforeStartPos = getText(editorAdaptor, 0, startPos);
-        return rangeForLastXmlTag(editorAdaptor, textBeforeStartPos);
-    }
-
-    private TextRange rangeForLastXmlTag(EditorAdaptor editorAdaptor, String text) throws CommandExecutionException {
-        Matcher matcher = tagPattern.matcher(text);
-        TextRange range = null;
-        while (matcher.find()) {
-            int matchStart = matcher.start();
-            int matchEnd = matcher.end();
-            range = getRange(editorAdaptor, matchStart, matchEnd);
-        }
-        
-        if (range != null) {
-            return range;
-        } else {
-            throw new CommandExecutionException("The cursor is not within an XML tag");
-        }
-    }
-    
     private String getText(EditorAdaptor editorAdaptor, int from, int to) {
         return editorAdaptor.getModelContent().getText(from, to - from);
     }
 
-    /**
-     * @param tagRange The range the tag lies within
-     * @return The contents of the tag
-     */
-    private String getTagName(TextRange tagRange, EditorAdaptor editorAdaptor) {
-    	String contents = editorAdaptor.getModelContent().getText(tagRange);
-    	Matcher matcher = tagNamePattern.matcher(contents);
-    	if (matcher.find()) {
-    	    return matcher.group(1);
-    	}
-    	return "";
-    }
-    
     private TextRange getRange(EditorAdaptor editorAdaptor, int start, int end) {
         Position matchBegin = editorAdaptor.getPosition().setModelOffset(start);
         Position matchEnd   = editorAdaptor.getPosition().setModelOffset(end);
         return new StartEndTextRange(matchBegin, matchEnd);
     }
+
 }


### PR DESCRIPTION
This came about from #433. I don't know much about Eclipse's API, so what I have may very well be wrong or not working. I tried to copy as much as I could understand. Note that I did not do a build. I don't know how to build the project etc. Just wanted to write down my idea and let people in the know see if there is a simpler way to achieve this.

Notable changes:
- Removed public methods: getUnbalancedOpenTag and getUnbalancedClosingTag. Not sure if needed, but they weren't needed for the algo that I had in mind.
- Removed most private methods.
- Renamed endTag variable to closeTag for consistency.
- Look for close tag first, as that is easier to parse for tag name, then search backwards for matching open tag.
