### PR TITLE
Fix #441: Update new split tab view position on the UI thread

### DIFF
--- a/plugins/ports/net.sourceforge.vrapper.plugin.splitEditor.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.splitEditor.eclipse/META-INF/MANIFEST.MF
@@ -17,5 +17,6 @@ Import-Package: org.eclipse.core.resources,
  org.eclipse.e4.ui.model.application.ui.basic,
  org.eclipse.e4.ui.services,
  org.eclipse.e4.ui.workbench.modeling,
+ org.eclipse.jface.text,
  org.eclipse.ui,
  org.eclipse.ui.part


### PR DESCRIPTION
Moved position update onto the UI thread so it is executed when
the UI reconfiguration is complete. The view position is adjusted
to match observable VIM behaviour -- keeping the cursor at a relative
offset to the top of the split.
