### PR TITLE
Allow macro or mapping containing <TAB> key.

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/VimConstants.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/VimConstants.java
@@ -65,6 +65,6 @@ public class VimConstants {
     private static Set<SpecialKey> createSpecialKeysAllowedForInsert() {
         return VimUtils.set(SpecialKey.BACKSPACE, SpecialKey.RETURN,
                 SpecialKey.ARROW_LEFT, SpecialKey.ARROW_RIGHT,
-                SpecialKey.ARROW_UP, SpecialKey.ARROW_DOWN);
+                SpecialKey.ARROW_UP, SpecialKey.ARROW_DOWN, SpecialKey.TAB);
     }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/InsertMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/InsertMode.java
@@ -463,6 +463,8 @@ public class InsertMode extends AbstractMode {
             String s;
             if (SpecialKey.RETURN.equals(stroke.getSpecialKey())) {
                 s = editorAdaptor.getConfiguration().getNewLine();
+            } else if (SpecialKey.TAB.equals(stroke.getSpecialKey())) {
+                s = "\t";
             } else {
                 s = String.valueOf(stroke.getCharacter());
             }


### PR DESCRIPTION
Issue #454 is about the TAB key not beind handled in Insert mode while remapping or replaying a macro. Since TAB is a SpecialKey, Insert mode didn't know what to insert (such a KeyStroke has no character). I simply added it to Insert mode to get it working.

The tab is inserted straight to Eclipse which will then place a literal tab or the equivalent number of spaces according to the Eclipse settings of the current editor.

This does mean the Vrapper tabstop options are ignored, but at the same time the user will see the same kind of tab as he would if placing it in insert. Keeping it simple like this also means that replace mode immediately works, as forcing a real tab or several spaces into the document means we can't use `smartInsert` and hence both InsertMode and ReplaceMode would need changing.
