### PR TITLE
fix #448: } motion behaves differently in visual mode

### DIFF
--- a/plugins/ports/net.sourceforge.vrapper.plugin.ipmotion.eclipse/src/net/sourceforge/vrapper/plugin/ipmotion/provider/ImprovedParagraphProvider.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.ipmotion.eclipse/src/net/sourceforge/vrapper/plugin/ipmotion/provider/ImprovedParagraphProvider.java
@@ -23,6 +23,6 @@ public class ImprovedParagraphProvider extends AbstractEclipseSpecificStateProvi
     
     @Override
     protected State<Command> visualModeBindings() {
-        return new VisualMotionState(Motion2VMC.CHARWISE, ImprovedParagraphMotion.PARAGRAPH_MOTIONS);
+        return new VisualMotionState(Motion2VMC.LINEWISE, ImprovedParagraphMotion.PARAGRAPH_MOTIONS);
     }
 }


### PR DESCRIPTION
I traced the problem in the issue #448 to this method in `ImprovedParagraphProvider` in the improved paragraph plugin: 

``` java
    @Override
    protected State<Command> visualModeBindings() {
        return new VisualMotionState(Motion2VMC.CHARWISE, ImprovedParagraphMotion.PARAGRAPH_MOTIONS);
    } 
```

Changing `Motion2VMC.CHARWISE` for `Motion2VMC.LINEWISE` seems to fix the problem. It makes sense to me since the paragraph motion sounds more like a linewise motion.

I am working on a test but, for some reason I cannot make it fail:

``` java
    @Test
    public void testParagrapForwardMotionLineWise() throws CommandExecutionException {
        Motion oneParagraphForward = ImprovedParagraphMotion.FORWARD;
        adaptor.changeMode(LinewiseVisualMode.NAME);
        assertEquals(LinewiseVisualMode.NAME, adaptor.getCurrentModeName());
        checkMotion(oneParagraphForward,
                "",'1',"\n"+
                "\n"+
                "2\n"+
                "\n"+
                "3\n",

                "1\n",
                '\n',
                "2\n"+
                "\n"+
                "3\n"
        );
        reloadEditorAdaptor();
    }
```
