### PR TITLE
Added escape character to regex to fix reverse incremental search

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/SearchCommandParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/SearchCommandParser.java
@@ -98,7 +98,7 @@ public class SearchCommandParser extends AbstractCommandParser {
 	public String getKeyWord() {
         String first = commandLine.getPrompt();
         String command = commandLine.getContents();
-        return command.split("(?<!\\\\)"+first)[0];
+        return command.split("(?<!\\\\)\\"+first)[0];
 	}
 
     private SearchOffset createSearchOffset(String keyword, String afterSearch) {


### PR DESCRIPTION
I noticed that reverse incremental search using `?` wasn't working. It looks like this was due to the `?` character not being escaped in the regex. I've added an escape character and reverse incremental search now functions as it should. 
