### PR TITLE
fix IllegalArgumentException in EclipseCursorAndSelection

### DIFF
--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -125,7 +125,17 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
     		//Just put the cursor at offset 0.
     		viewOffset = 0;
     	}
-        textViewer.getTextWidget().setSelection(viewOffset);
+    	try {
+    	    textViewer.getTextWidget().setSelection(viewOffset);
+        } catch (IllegalArgumentException e) {
+            /**
+             * This exception should only happen if the cursor is on the
+             * end of a line and the newlines are multi-byte characters.
+             * Which is to say, Windows (\r\n).  If this happens, step
+             * back one character and try again.
+             */
+    	    textViewer.getTextWidget().setSelection(viewOffset - 1);
+        }
         if (columnPolicy == StickyColumnPolicy.RESET_EOL) {
             stickToEOL = false;
             updateStickyColumn(viewOffset);


### PR DESCRIPTION
Suppose I have this two lines:

```
import static net.sourceforge.vrapper.keymap.StateUtils.union;
import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafBind;
```

If I put the cursor over the i in the first `import` and enter visual mode, then search for "import" and hit enter, then, without leaving visual mode, search for "static" and hit enter, nothing happens and an IllegalArgumentException is thrown.
Apparently the reason is Windows new lines(\r\n).  
I found in other class that in this situations the way to go is to step back one character and try again.

Where can I look in order to learn how to make a test for "Search in VisualMode"?
