### PR TITLE
Make outer quote text object include next whitespace

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
@@ -1219,16 +1219,16 @@ public class NormalModeTests extends CommandTestCase {
                 "before ",' ',"after");
         checkCommand(forKeySeq("da'"),
                 "before 'mi",'d',"d\\'le' after",
-                "before ",' ',"after");
+                "before ",'a',"fter");
         checkCommand(forKeySeq("di'"),
                 "'before mi",'d',"dle after'",
                 "'",'\'',"");
         checkCommand(forKeySeq("di'"),
                 "\\'before mi",'d',"dle after\\'",
                 "\\'before mi",'d',"dle after\\'");
-	}
-	
-	@Test
+    }
+
+    @Test
     public void test_dip() {
         checkCommand(forKeySeq("dip"),
                 "",'1',"ac\n\n3ac\n4ac\n\n  \n7ac\n\n  \n\n11ac\n12ac",

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VisualModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VisualModeTests.java
@@ -134,10 +134,6 @@ public class VisualModeTests extends VisualTestCase {
         checkCommand(forKeySeq("aw"),
                 false,  "It's Some","th","ing interesting.",
                 false,  "It's ","Something ","interesting.");
-        //FIXME Vim actually selects the next space as well
-        checkCommand(forKeySeq("a'"),
-                false,  "It's 'Some","th","ing' interesting.",
-                false,  "It's ","'Something'"," interesting.");
         checkCommand(forKeySeq("i'"),
                 false,  "It's 'Some","th","ing' interesting.",
                 false,  "It's '","Something","' interesting.");
@@ -147,6 +143,24 @@ public class VisualModeTests extends VisualTestCase {
         checkCommand(forKeySeq("3i'"),
                 false,  "It's 'Some","th","ing' interesting.",
                 false,  "It's ","'Something'"," interesting.");
+        checkCommand(forKeySeq("a'"),
+                false,  "It's 'Some","th","ing' interesting.",
+                false,  "It's ","'Something' ","interesting.");
+        checkCommand(forKeySeq("a'"),
+                false,  "It's 'Some","th","ing'  interesting.",
+                false,  "It's ","'Something'  ","interesting.");
+        checkCommand(forKeySeq("a'"),
+                false,  "It's Something 'i","nt","eresting'\nisn't it?",
+                false,  "It's Something ","'interesting'","\nisn't it?");
+        checkCommand(forKeySeq("a'"),
+                false,  "It's Something 'i","nt","eresting'  \nisn't it?",
+                false,  "It's Something ","'interesting'  ","\nisn't it?");
+        checkCommand(forKeySeq("a'"),
+                false,  "It's Something 'i","nt","eresting'",
+                false,  "It's Something ","'interesting'","");
+        checkCommand(forKeySeq("3a'"),
+                false,  "It's Something 'i","nt","eresting'  isn't it?",
+                false,  "It's Something ","'interesting'  ","isn't it?");
     }
 
     @Test


### PR DESCRIPTION
There was an inconsistency with Vim: `a"` there actually selects the
quotes plus any extra whitespace to the right of the quotes. Instead
`2i"` should be used to select everything - including the quotes - but
nothing extra.

Related to #522.

Users should be warned that this behavior changed; if they want the old behavior (different from Vim) they can put the following in their `.vrapperrc`: 

```
onoremap a' 2i'
onoremap a" 2i"
onoremap a` 2i`

vnoremap a' 2i'
vnoremap a" 2i"
vnoremap a` 2i`
```
