### PR TITLE
Add paste command for blockwise visual mode.

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockPasteHelper.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockPasteHelper.java
@@ -16,71 +16,79 @@ import net.sourceforge.vrapper.vim.register.TextBlockRegisterContent;
 abstract public class BlockPasteHelper {
 
     static public void execute(EditorAdaptor editorAdaptor, int count, int startOfs, boolean placeCursorAfter) {
-        final CursorService cursorService = editorAdaptor.getCursorService();
         RegisterContent registerContent = editorAdaptor.getRegisterManager().getActiveRegister().getContent();
-        TextContent content = editorAdaptor.getModelContent();
-        int offset = editorAdaptor.getPosition().getModelOffset();
-        LineInformation line = content.getLineInformationOfOffset(offset);
+        final Position pos = editorAdaptor.getPosition();
         try {
-            final int startLine = line.getNumber();
             editorAdaptor.getHistory().beginCompoundChange();
-            final TextBlockRegisterContent rect = (TextBlockRegisterContent) registerContent;
-            int newCursorOfs = editorAdaptor.getPosition().addModelOffset(startOfs).getModelOffset();
-            final int vWidth = rect.getVisualWidth();
-            for (int i = 0; i < rect.getNumLines(); ++i) {
-                Position pastePos;
-                if (startLine + i >= content.getNumberOfLines() - 1) {
-                    // Insert a new empty line if at the of the document.
-                    content.replace(content.getTextLength(), 0, 
-                            editorAdaptor.getConfiguration().getNewLine());
-                }
-                LineInformation pasteLine = content.getLineInformation(startLine + i);
-                int vOffset = cursorService.getVisualOffset(editorAdaptor.getPosition());
-                for (int c = 0; c < count; ++c) {
-                    pastePos = cursorService.getPositionByVisualOffset(startLine + i, vOffset);
-                    if (pastePos == null) {
-                        pastePos = cursorService.newPositionForModelOffset(pasteLine.getEndOffset());
-                        final int lineEndVOfs = cursorService.getVisualOffset(pastePos);
-                        //
-                        // "Extend" the paste line with spaces until it reaches vOffset.
-                        //
-                        final int padding = cursorService.visualWidthToChars(vOffset - lineEndVOfs);
-                        content.replace(pasteLine.getEndOffset(), 0, StringUtils.multiply(" ", padding));
-                        pastePos = pastePos.addModelOffset(padding);
-                    }
-                    // Refresh line information if extended.
-                    pasteLine = content.getLineInformation(startLine + i);
-                    if (startOfs > 0 && pasteLine.getEndOffset() == pastePos.getModelOffset()) {
-                        content.replace(pasteLine.getEndOffset(), 0, " ");
-                    }
-                    //
-                    // Paste after the character at vOffset.
-                    //
-                    final String blockLine = rect.getLine(i);
-                    content.replace(pastePos.addModelOffset(startOfs).getModelOffset(), 0, blockLine);
-                    //
-                    // Right-pad with spaces if block-line is shorter and not at EOL.
-                    //
-                    pastePos = pastePos.addModelOffset(blockLine.length());
-                    if (pastePos.getModelOffset() + startOfs < (pasteLine.getEndOffset() + blockLine.length()) || c != count - 1) {
-                        final int vEndOfs = cursorService.getVisualOffset(pastePos);
-                        final int padding = cursorService.visualWidthToChars(vOffset + vWidth - vEndOfs) + 1;
-                        content.replace(pastePos.addModelOffset(startOfs).getModelOffset(), 0,
-                                StringUtils.multiply(" ", padding));
-                        pastePos = pastePos.addModelOffset(padding);
-                    }
-                    // Set vOffset for the next block line for count > 1.
-                    vOffset = cursorService.getVisualOffset(pastePos);
-                    if (placeCursorAfter) {
-                        newCursorOfs = pastePos.getModelOffset() + startOfs;
-                    }
-                }
-            }
-            Position destination = cursorService.newPositionForModelOffset(newCursorOfs);
+            int newCursorOfs = execute(editorAdaptor, count, startOfs,
+                    placeCursorAfter, registerContent, pos);
+            Position destination = editorAdaptor.getCursorService().newPositionForModelOffset(newCursorOfs);
             editorAdaptor.setPosition(destination, StickyColumnPolicy.ON_CHANGE);
         } finally {
             editorAdaptor.getHistory().endCompoundChange();
         }
+    }
+
+    static public int execute(EditorAdaptor editorAdaptor, int count,
+            int startOfs, boolean placeCursorAfter, RegisterContent registerContent, Position pos) {
+        final CursorService cursorService = editorAdaptor.getCursorService();
+        final TextContent content = editorAdaptor.getModelContent();
+        LineInformation line = content.getLineInformationOfOffset(pos.getModelOffset());
+        final int startLine = line.getNumber();
+        final TextBlockRegisterContent rect = (TextBlockRegisterContent) registerContent;
+        int newCursorOfs = cursorService.shiftPositionForModelOffset(
+                pos.getModelOffset(), startOfs, false).getModelOffset();
+        final int vWidth = rect.getVisualWidth();
+        for (int i = 0; i < rect.getNumLines(); ++i) {
+            Position pastePos;
+            if (startLine + i >= content.getNumberOfLines() - 1) {
+                // Insert a new empty line if at the of the document.
+                content.replace(content.getTextLength(), 0,
+                        editorAdaptor.getConfiguration().getNewLine());
+            }
+            LineInformation pasteLine = content.getLineInformation(startLine + i);
+            int vOffset = cursorService.getVisualOffset(pos);
+            for (int c = 0; c < count; ++c) {
+                pastePos = cursorService.getPositionByVisualOffset(startLine + i, vOffset);
+                if (pastePos == null) {
+                    pastePos = cursorService.newPositionForModelOffset(pasteLine.getEndOffset());
+                    final int lineEndVOfs = cursorService.getVisualOffset(pastePos);
+                    //
+                    // "Extend" the paste line with spaces until it reaches vOffset.
+                    //
+                    final int padding = cursorService.visualWidthToChars(vOffset - lineEndVOfs);
+                    content.replace(pasteLine.getEndOffset(), 0, StringUtils.multiply(" ", padding));
+                    pastePos = pastePos.addModelOffset(padding);
+                }
+                // Refresh line information if extended.
+                pasteLine = content.getLineInformation(startLine + i);
+                if (startOfs > 0 && pasteLine.getEndOffset() == pastePos.getModelOffset()) {
+                    content.replace(pasteLine.getEndOffset(), 0, " ");
+                }
+                //
+                // Paste after the character at vOffset.
+                //
+                final String blockLine = rect.getLine(i);
+                content.replace(pastePos.addModelOffset(startOfs).getModelOffset(), 0, blockLine);
+                //
+                // Right-pad with spaces if block-line is shorter and not at EOL.
+                //
+                pastePos = pastePos.addModelOffset(blockLine.length());
+                if (pastePos.getModelOffset() + startOfs < (pasteLine.getEndOffset() + blockLine.length()) || c != count - 1) {
+                    final int vEndOfs = cursorService.getVisualOffset(pastePos);
+                    final int padding = cursorService.visualWidthToChars(vOffset + vWidth - vEndOfs) + 1;
+                    content.replace(pastePos.addModelOffset(startOfs).getModelOffset(), 0,
+                            StringUtils.multiply(" ", padding));
+                    pastePos = pastePos.addModelOffset(padding);
+                }
+                // Set vOffset for the next block line for count > 1.
+                vOffset = cursorService.getVisualOffset(pastePos);
+                if (placeCursorAfter) {
+                    newCursorOfs = pastePos.getModelOffset() + startOfs;
+                }
+            }
+        }
+        return newCursorOfs;
     }
 
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockWiseSelection.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockWiseSelection.java
@@ -155,8 +155,9 @@ public class BlockWiseSelection implements Selection {
                 editorAdaptor.getModelContent(), cursorService);
         TextBlockRegisterContent blockContent = new TextBlockRegisterContent(textBlock.endVisualOffset - textBlock.startVisualOffset);
         for (int line = textBlock.startLine; line <= textBlock.endLine; ++line) {
+            final LineInformation lineInformation = textContent.getLineInformation(line);
             final Position start = cursorService.getPositionByVisualOffset(line, textBlock.startVisualOffset);
-            if (start == null) {
+            if (start == null || lineInformation.getLength() == 0) {
                 // no characters at the visual offset, yank empty line
                 blockContent.appendLine("");
                 continue;
@@ -166,7 +167,7 @@ public class BlockWiseSelection implements Selection {
             int endOfs;
             if (end == null) {
                 // the line is shorter that the end offset
-                endOfs = textContent.getLineInformation(line).getEndOffset();
+                endOfs = lineInformation.getEndOffset();
             } else {
                 endOfs = end.addModelOffset(1).getModelOffset();
             }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockwisePasteCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockwisePasteCommand.java
@@ -1,0 +1,97 @@
+package net.sourceforge.vrapper.vim.commands;
+
+import net.sourceforge.vrapper.platform.HistoryService;
+import net.sourceforge.vrapper.platform.TextContent;
+import net.sourceforge.vrapper.utils.ContentType;
+import net.sourceforge.vrapper.utils.LineInformation;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.StringUtils;
+import net.sourceforge.vrapper.utils.TextRange;
+import net.sourceforge.vrapper.utils.VimUtils;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.BlockWiseSelection.TextBlock;
+import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+import net.sourceforge.vrapper.vim.register.RegisterContent;
+import net.sourceforge.vrapper.vim.register.TextBlockRegisterContent;
+
+public class BlockwisePasteCommand extends CountAwareCommand {
+
+    public final static BlockwisePasteCommand INSTANCE = new BlockwisePasteCommand();
+
+    @Override
+    public CountAwareCommand repetition() {
+        return null;
+    }
+
+    @Override
+    public void execute(EditorAdaptor editorAdaptor, int count)
+            throws CommandExecutionException {
+        if (count == Command.NO_COUNT_GIVEN)
+            count = 1;
+        editorAdaptor.rememberLastActiveSelection();
+        final BlockWiseSelection selection = (BlockWiseSelection) editorAdaptor.getSelection();
+        final TextContent content = editorAdaptor.getModelContent();
+        final TextBlock rect = BlockWiseSelection.getTextBlock(
+                selection.getFrom(), selection.getTo(), content,
+                editorAdaptor.getCursorService());
+        final TextRange blockRange = selection.getRegion(editorAdaptor, NO_COUNT_GIVEN);
+        final RegisterContent registerContent = editorAdaptor
+                .getRegisterManager().getActiveRegister().getContent();
+        final ContentType pastingContentType = registerContent.getPayloadType();
+        final HistoryService history = editorAdaptor.getHistory();
+        history.beginCompoundChange();
+        history.lock("block-paste");
+        try {
+            //
+            // Regardless of the paste content -- delete the block first.
+            //
+            SelectionBasedTextOperationCommand.doIt(editorAdaptor,
+                    NO_COUNT_GIVEN, DeleteOperation.INSTANCE, content,
+                    blockRange, true);
+            int position = blockRange.getLeftBound().getModelOffset();
+            switch (pastingContentType) {
+            case TEXT: {
+                //
+                // Create a fake text block of equal line count with the text
+                // replicated on every line and multiplied by count.
+                //
+                final TextBlockRegisterContent repl = new TextBlockRegisterContent(0);
+                final String text = StringUtils.multiply(
+                    VimUtils.replaceNewLines(registerContent.getText(), ""), count);
+                for (int l = rect.startLine; l <= rect.endLine; ++l) {
+                    repl.appendLine(text);
+                }
+                // Paste the fake block at old block position.
+                position = BlockPasteHelper.execute(editorAdaptor, 1, 0, false,
+                        repl, blockRange.getLeftBound());
+                break;
+            }
+            case TEXT_RECTANGLE: {
+                position = BlockPasteHelper.execute(editorAdaptor, count, 0,
+                        false, registerContent, blockRange.getLeftBound());
+                break;
+            }
+            case LINES: {
+                String text = StringUtils.multiply(registerContent.getText(), count);
+                final String newLine = editorAdaptor.getConfiguration().getNewLine();
+                text = newLine + VimUtils.stripLastNewline(VimUtils.replaceNewLines(text, newLine));
+                final int pastePos = content.getLineInformation(rect.endLine).getEndOffset();
+                content.replace(pastePos, 0, text);
+                final LineInformation firstPastedLine = content.getLineInformation(rect.endLine + 1);
+                position = VimUtils.getFirstNonWhiteSpaceOffset(content, firstPastedLine);
+                break;
+            }
+            default:
+                break;
+            }
+            final Position destination = editorAdaptor.getCursorService()
+                    .newPositionForModelOffset(position);
+            editorAdaptor.setPosition(destination, StickyColumnPolicy.ON_CHANGE);
+        } finally {
+            history.unlock("block-paste");
+            history.endCompoundChange();
+            LeaveVisualModeCommand.doIt(editorAdaptor);
+        }
+    }
+
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SelectionBasedTextOperationCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SelectionBasedTextOperationCommand.java
@@ -113,8 +113,8 @@ public class SelectionBasedTextOperationCommand extends CountAwareCommand {
             for (int line = block.startLine + 1; line <= endLine; ++line) {
                 final Position runStart = cursorService.getPositionByVisualOffset(line, block.startVisualOffset);
                 Position runEnd = cursorService.getPositionByVisualOffset(line, block.endVisualOffset);
-                if (runEnd == null) {
-                    final LineInformation lineInfo = textContent.getLineInformation(line);
+                final LineInformation lineInfo = textContent.getLineInformation(line);
+                if (runEnd == null || lineInfo.getLength() == 0) {
                     runEnd = cursorService.newPositionForModelOffset(lineInfo.getEndOffset());
                 } else {
                     runEnd = runEnd.addModelOffset(1);
@@ -177,7 +177,7 @@ public class SelectionBasedTextOperationCommand extends CountAwareCommand {
 			LeaveVisualModeCommand.doIt(editorAdaptor);
 	}
 
-    static private void doIt(final EditorAdaptor editorAdaptor,
+    static public void doIt(final EditorAdaptor editorAdaptor,
             final int count, TextOperation command,
             final TextContent textContent, final TextRange blockRange,
             boolean changeMode) throws CommandExecutionException {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
@@ -5,8 +5,10 @@ import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.changeCaret
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.convertKeyStroke;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafBind;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.state;
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.counted;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.transitionBind;
 import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.vim.CountingState;
 import net.sourceforge.vrapper.keymap.vim.VisualMotionState;
 import net.sourceforge.vrapper.keymap.vim.VisualMotionState.Motion2VMC;
 import net.sourceforge.vrapper.platform.CursorService;
@@ -25,6 +27,7 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.VimConstants;
 import net.sourceforge.vrapper.vim.commands.BlockWiseSelection;
 import net.sourceforge.vrapper.vim.commands.BlockWiseSelection.TextBlock;
+import net.sourceforge.vrapper.vim.commands.BlockwisePasteCommand;
 import net.sourceforge.vrapper.vim.commands.BlockwiseYankCommand;
 import net.sourceforge.vrapper.vim.commands.ChangeToInsertModeCommand;
 import net.sourceforge.vrapper.vim.commands.Command;
@@ -286,7 +289,9 @@ public class BlockwiseVisualMode extends AbstractVisualMode {
                         convertKeyStroke(
                                 ReplaceCommand.VisualBlock.VISUALBLOCK_KEYSTROKE,
                                 VimConstants.PRINTABLE_KEYSTROKES_WITH_NL))
-                ), parentState);
+                ),
+                CountingState.wrap(state(leafBind('p', (Command) BlockwisePasteCommand.INSTANCE))),
+                parentState);
     }
     
     @Override


### PR DESCRIPTION
Adds support for `p` for the blockwise visual mode. Useful for replacing one block of text with another.
Another interesting use case is to paste a text run into a blockwise selection -- the text is replicated for every line in the block (count is also applicable). Line pasting is also implemented to match VIM's behaviour.
