### PR TITLE
Command line position fixed for GTK.

### DIFF
--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/ui/CommandLineUIFactory.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/ui/CommandLineUIFactory.java
@@ -99,7 +99,9 @@ public class CommandLineUIFactory {
                     && (parent.getVerticalBar() == null
                         || verScroll == parent.getVerticalBar().getSelection())) {
                 commandLineText.setLocation(0, bottom - size.y);
-                commandLineText.redraw();
+                if (!"gtk".equals(SWT.getPlatform())) {
+                    commandLineText.redraw();
+                }
             } else {
                 parent.redraw();
                 horScroll = parent.getHorizontalBar().getSelection();


### PR DESCRIPTION
When command line is shown and area is scrolled for example replace witch check:

```
     :%s/xyz/xyz/gc
```

then on GTK systems the command line is positioned wrong when text area is scrolled. This fix leave the command line on bottom of the textarea.
