### PR TITLE
Update documentation

### DIFF
--- a/website/documentation/commandline_commands.html
+++ b/website/documentation/commandline_commands.html
@@ -6,6 +6,9 @@ Commands may be chained with a <code>|</code> character between them. For exampl
 <code>:'<,'>s/foo/bar/g  |  '<,'>s/baz/bat/g</code>
 <br/><br/>
 
+Vrapper allows abbreviated commands only when there are no conflicts (e.g. custom commands defined in <code>.vrapperrc</code>).
+<br/><br/>
+
 <table class="commands">
     <tr>
         <th>Command</th>


### PR DESCRIPTION
- Add missing ':edit' command
- Add note about possible conflict with abbreviated commands
