### PR TITLE
Update developer wiki link on SourceForge to point to GitHub wiki.

### DIFF
--- a/website/home/index.php
+++ b/website/home/index.php
@@ -29,7 +29,7 @@
                       <p>GitHub makes it much easier for contributors to submit code changes, bug fixes, and new features.  If you'd like to contribute to Vrapper just initiate a Pull Request on our GitHub project.</p>
                       <p>The SourceForge project will remain active because it hosts our website, bug tracker, wiki, forums, direct file downloads, and Eclipse update site.  The Git repository on SourceForge will only contain the state of the code for the most recent stable release.  Basically, everything other than actively developed code is still on SourceForge.</p>
                       <p>If you'd like to contribute to Vrapper but need some help, here are a couple Developer Wiki pages we've put together:<br/>
-                      <a href="https://sourceforge.net/apps/trac/vrapper/wiki">Developer Wiki</a></p>
+                      <a href="https://github.com/vrapper/vrapper/wiki">Developer Wiki</a></p>
               </div>
               <script type="text/javascript" src="http://www.openhub.net/p/318170/widgets/project_basic_stats.js"></script>
         </div>


### PR DESCRIPTION
The SourceForge page listed a Developer Wiki link that pointed to a
SourceForge Trac Wiki which apparently no longer exists.  This commit
updates the link to the existing GitHub wiki.