### PR TITLE
Change COPY_MOVE pattern

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
@@ -105,6 +105,50 @@ public class CommandLineTests extends VimTestCase {
     	command = parser.parseAndExecute(":", "?foo?,/bar/d");
     	assertNotNull(command);
     	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "m +1");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "m+2");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "mov +2");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "mo+2");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "move+1");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "copy +1");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "copy+2");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "co +1");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "co+2");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "t +1");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
+
+    	command = parser.parseAndExecute(":", "t+2");
+    	assertNotNull(command);
+    	assertTrue(command instanceof LineRangeOperationCommand);
     }
     
     @Test

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/LineRangeOperationCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/LineRangeOperationCommand.java
@@ -33,7 +33,7 @@ public class LineRangeOperationCommand extends CountIgnoringNonRepeatableCommand
 	private static final Pattern START_AND_STOP = Pattern.compile(START_SEL_RE + END_SEL_RE + "(\\D.*)");
 	private static final Pattern JUST_START = Pattern.compile(START_SEL_RE + "(\\D.*)");
 	private static final Pattern JUST_STOP = Pattern.compile("^" + END_SEL_RE + "(\\D.*)");
-	private static final Pattern COPY_MOVE = Pattern.compile("^(t|co(p(y)?)?|m(o(v(e?)?)?)?)\\s+.*");
+	private static final Pattern COPY_MOVE = Pattern.compile("^(t|co(p(y)?)?|m(o(v(e?)?)?)?)(\\s+|\\+).*");
 	private String definition;
     private String startStr = "";
     private String stopStr = "";


### PR DESCRIPTION
Accept optional plus symbol instead of whitespace in Copy-Move command pattern.

Fix #589

Note: I know that you are busy with the preparations for the next release, so please postpone the analysis of this PR to another time, I'm just posting this now so I do not forget of doing it in the future.
