### PR TITLE
If no pattern is defined for Ex command, try using last search.

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/ExCommandOperation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/ExCommandOperation.java
@@ -79,8 +79,16 @@ public class ExCommandOperation extends SimpleTextOperation {
 		//grab text between delimiters
 		String pattern = definition.substring(1, patternEnd);
 		
-		if(definition.length() <= patternEnd) {
-			//pattern was defined, but no command
+		if (pattern.length() == 0) {
+			// if no pattern defined, use last search
+			pattern = editorAdaptor.getRegisterManager().getRegister("/").getContent().getText();
+			if (pattern.length() == 0) {
+				return;
+			}
+		}
+
+		if (definition.length() <= patternEnd) {
+			// pattern was defined, but no command
 			return;
 		}
 		


### PR DESCRIPTION
Previously `g//d` will delete the entire content of an editor. With this
commit, if no pattern is specified, `ExCommandOperation` will check if a
last search is available. If not, it will return.