### PR TITLE
Should we use a negative limit with String.split in substitutions?

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/SubstitutionDefinition.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/SubstitutionDefinition.java
@@ -20,7 +20,7 @@ public class SubstitutionDefinition {
 		//whatever character is after 's' is our delimiter
 		String delim = "" + def.charAt( def.indexOf('s') + 1);
 		//split on the delimiter, unless that delimiter is escaped with a backslash (:s/\/\///)
-		String[] fields = def.split("(?<!\\\\)"+delim);
+		String[] fields = def.split("(?<!\\\\)"+delim, -1);
 		find = "";
 		replace = "";
 		flags = "";


### PR DESCRIPTION
Calling split with zero or no limit will discard trailing empty fields.
For that reason, s// will not delete previous search. Using a negative
limit allows this to work because it split the definition into [s,"",""]