### PR TITLE
EXPERIMENTAL Fake caret

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/CaretType.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/CaretType.java
@@ -2,5 +2,9 @@ package net.sourceforge.vrapper.utils;
 
 
 public enum CaretType {
-	VERTICAL_BAR, RECTANGULAR, LEFT_SHIFTED_RECTANGULAR, HALF_RECT, UNDERLINE;
+	VERTICAL_BAR, RECTANGULAR, UNDERLINE, HALF_RECT,
+	/** Special caret type drawn to left of the caret position.
+	 *  <br/><b>Don't use this in Vrapper Core or in plugins!</b>
+	 */
+	LEFT_SHIFTED_RECTANGULAR;
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/ChangeCaretShapeCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/ChangeCaretShapeCommand.java
@@ -7,7 +7,6 @@ public class ChangeCaretShapeCommand extends CountIgnoringNonRepeatableCommand {
 
     private static final ChangeCaretShapeCommand VERTICAL_BAR = new ChangeCaretShapeCommand(CaretType.VERTICAL_BAR);
     private static final ChangeCaretShapeCommand RECTANGULAR = new ChangeCaretShapeCommand(CaretType.RECTANGULAR);
-    private static final ChangeCaretShapeCommand LEFT_SHIFTED_RECTANGULAR = new ChangeCaretShapeCommand(CaretType.LEFT_SHIFTED_RECTANGULAR);
     private static final ChangeCaretShapeCommand HALF_RECT = new ChangeCaretShapeCommand(CaretType.HALF_RECT);
     private static final ChangeCaretShapeCommand UNDERLINE = new ChangeCaretShapeCommand(CaretType.UNDERLINE);
 
@@ -23,14 +22,12 @@ public class ChangeCaretShapeCommand extends CountIgnoringNonRepeatableCommand {
             return VERTICAL_BAR;
         case RECTANGULAR:
             return RECTANGULAR;
-        case LEFT_SHIFTED_RECTANGULAR:
-            return LEFT_SHIFTED_RECTANGULAR;
         case HALF_RECT:
             return HALF_RECT;
         case UNDERLINE:
             return UNDERLINE;
         default:
-            throw new IllegalArgumentException("unknown caret type: "+type);
+            throw new IllegalArgumentException("unsupported caret type: " + type);
         }
     }
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
@@ -312,8 +312,8 @@ public class BlockwiseVisualMode extends AbstractVisualMode {
     
     @Override
     public void fixCaret() {
-        final CaretType caret = CaretType.LEFT_SHIFTED_RECTANGULAR;
-//        if (editorAdaptor.getConfiguration().get(Options.SELECTION).equals(Selection.EXLUSIVE))
+        CaretType caret = CaretType.RECTANGULAR;
+//        if (editorAdaptor.getConfiguration().get(Options.SELECTION).equals(Selection.EXCLUSIVE))
 //            caret = CaretType.VERTICAL_BAR;
         editorAdaptor.getCursorService().setCaret(caret);
     }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/VisualMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/VisualMode.java
@@ -47,19 +47,19 @@ public class VisualMode extends AbstractVisualMode {
         String selectionType = editorAdaptor.getConfiguration().get(Options.SELECTION);
         CaretType type;
         if (Selection.INCLUSIVE.equals(selectionType)) {
-            if (editorAdaptor.getSelection().isReversed()) {
+//            if (editorAdaptor.getSelection().isReversed()) {
                 type = CaretType.RECTANGULAR;
-            } else {
-                Selection selection = editorAdaptor.getSelection();
-                int to = selection.getTo().getModelOffset();
-                TextContent modelContent = editorAdaptor.getModelContent();
-                LineInformation li = modelContent.getLineInformationOfOffset(to);
-                if (to == li.getEndOffset() && to < modelContent.getTextLength()) {
-                    type = CaretType.RECTANGULAR;
-                } else {
-                    type = CaretType.LEFT_SHIFTED_RECTANGULAR;
-                }
-            }
+//            } else {
+//                Selection selection = editorAdaptor.getSelection();
+//                int to = selection.getTo().getModelOffset();
+//                TextContent modelContent = editorAdaptor.getModelContent();
+//                LineInformation li = modelContent.getLineInformationOfOffset(to);
+//                if (to == li.getEndOffset() && to < modelContent.getTextLength()) {
+//                    type = CaretType.RECTANGULAR;
+//                } else {
+//                    type = CaretType.LEFT_SHIFTED_RECTANGULAR;
+//                }
+//            }
         } else if (Selection.EXCLUSIVE.equals(selectionType)) {
             type = CaretType.VERTICAL_BAR;
         } else {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -27,6 +27,8 @@ import net.sourceforge.vrapper.vim.Options;
 import net.sourceforge.vrapper.vim.commands.Selection;
 import net.sourceforge.vrapper.vim.commands.SimpleSelection;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+import net.sourceforge.vrapper.vim.modes.InsertMode;
+import net.sourceforge.vrapper.vim.modes.NormalMode;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -93,9 +95,11 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
     private CaretType caretType = null;
     private Point caretCachedSize;
     private FakeCaretPainter fakeCaretPainter;
+    private VrapperModeRecorder vrapperModeRecorder;
 
-    public EclipseCursorAndSelection(final Configuration configuration,
+    public EclipseCursorAndSelection(VrapperModeRecorder vrapperModeRecorder, final Configuration configuration,
             EditorInfo editorInfo, final ITextViewer textViewer, final EclipseTextContent textContent) {
+        this.vrapperModeRecorder = vrapperModeRecorder;
         this.configuration = configuration;
         this.editorInfo = editorInfo;
         this.textViewer = textViewer;
@@ -543,7 +547,9 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
                 return;
             }
             StyledText text = textViewer.getTextWidget();
-            if (text.getSelectionCount() == 0) {
+            // Never move caret back in Normal or Insert / Select mode
+            if (text.getSelectionCount() == 0
+                    || (vrapperModeRecorder.getCurrentMode() instanceof InsertMode)) {
                 return;
             }
             // Forces caret visibility for blockwise mode: normally it is disabled all the time.

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -558,20 +558,34 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 //            gc.setForeground(text.getSelectionBackground());
 //            gc.setBackground(text.getSelectionForeground());
             Position to = getSelection().getTo();
+            if (VrapperLog.isDebugEnabled()) {
+                VrapperLog.debug("To: V" + to.getViewOffset() + "/M" + to.getModelOffset());
+            }
             boolean isInclusive = Selection.INCLUSIVE.equals(configuration.get(Options.SELECTION));
             int offset = to.getViewOffset();
+            // Selection is on some character in a fold?
+            if (offset <= 0) {
+                VrapperLog.debug("In a fold");
+                return;
+            }
             if (textViewer.getDocument().getLength() == to.getModelOffset() && isInclusive) {
                 offset--;
             }
             Rectangle caretBounds;
-            if (isInclusive) {
-                caretBounds = text.getTextBounds(offset, offset);
-            } else {
+//            if (isInclusive) {
+//                caretBounds = text.getTextBounds(offset, offset);
                 Point visualOffset = text.getLocationAtOffset(offset);
-                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, 2, text.getLineHeight(offset));
-            }
+                Point carretSize = text.getCaret().getSize();
+//                caretBounds.height = carretSize.y;
+//                caretBounds.width = carretSize.x;
+//                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, carretSize.x, carretSize.y);
+//            } else {
+//                Point visualOffset = text.getLocationAtOffset(offset);
+//                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, 2, text.getLineHeight(offset));
+//            }
 //            gc.fillRectangle(caretBounds);
-            text.getCaret().setBounds(caretBounds);
+//            text.getCaret().setBounds(caretBounds);
+            text.getCaret().setLocation(visualOffset);
         }
     }
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -552,6 +552,11 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
                     || (vrapperModeRecorder.getCurrentMode() instanceof InsertMode)) {
                 return;
             }
+            // Mark selection as "conflicted" - we're in Normal mode but somehow a selection exists
+            else if (vrapperModeRecorder.getCurrentMode() instanceof NormalMode) {
+                setCaret(CaretType.UNDERLINE);
+                return;
+            }
             // Forces caret visibility for blockwise mode: normally it is disabled all the time.
             // Regular visual modes should have it visible anyway.
             // [TODO] Maybe check if this blockwise visual selection is done through vrapper. A user

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -299,38 +299,38 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
         } else {
             IDocument document = textViewer.getDocument();
             int start = newSel.getStart().getModelOffset();
-            int end = newSel.getEnd().getModelOffset();
+//            int end = newSel.getEnd().getModelOffset();
             int length = !newSel.isReversed() ? newSel.getModelLength() : -newSel.getModelLength();
-            int documentLength = document.getLength();
-            IRegion lastLineInfo;
-            try {
-                lastLineInfo = document.getLineInformationOfOffset(end);
-            } catch (BadLocationException e) { // Shouldn't really happen...
-                selectionInProgress = false;
-                throw new VrapperPlatformException("Failed to get line info for last line of sel, "
-                        + "M " + end, e);
-            }
+//            int documentLength = document.getLength();
+//            IRegion lastLineInfo;
+//            try {
+//                lastLineInfo = document.getLineInformationOfOffset(end);
+//            } catch (BadLocationException e) { // Shouldn't really happen...
+//                selectionInProgress = false;
+//                throw new VrapperPlatformException("Failed to get line info for last line of sel, "
+//                        + "M " + end, e);
+//            }
             // Linewise selection includes final newline and so Eclipse will put the caret in column
             // 0 of the next line. We want a blinking caret at the end of the previous line instead,
             // simply shrink the selection to the previous line.
-            if (ContentType.LINES.equals(contentType)) {
-                // Special cases:
-                // - Last line of document may contain characters, don't alter selection
-                // - A reversed selection needs to show its caret in column 0, don't alter selection
-                if ((end == documentLength && lastLineInfo.getLength() == 0)
-                        || ! newSel.isReversed()) {
-                    end = safeAddModelOffset(end, end - 1, true);
-                    length = end - start;
-                }
-            } else if (ContentType.TEXT.equals(contentType)) {
-                boolean isInclusive = Selection.INCLUSIVE.equals(configuration.get(Options.SELECTION));
-                if (isInclusive && ! newSel.isReversed() && start != end && lastLineInfo.getOffset() == end) {
-                    // [NOTE] The caret must be updated as well, this is handled in
-                    // VisualMode.fixCaret()
-                    end = safeAddModelOffset(end, end - 1, true);
-                    length = end - start;
-                }
-            }
+//            if (ContentType.LINES.equals(contentType)) {
+//                // Special cases:
+//                // - Last line of document may contain characters, don't alter selection
+//                // - A reversed selection needs to show its caret in column 0, don't alter selection
+//                if ((end == documentLength && lastLineInfo.getLength() == 0)
+//                        || ! newSel.isReversed()) {
+//                    end = safeAddModelOffset(end, end - 1, true);
+//                    length = end - start;
+//                }
+//            } else if (ContentType.TEXT.equals(contentType)) {
+//                boolean isInclusive = Selection.INCLUSIVE.equals(configuration.get(Options.SELECTION));
+//                if (isInclusive && ! newSel.isReversed() && start != end && lastLineInfo.getOffset() == end) {
+//                    // [NOTE] The caret must be updated as well, this is handled in
+//                    // VisualMode.fixCaret()
+//                    end = safeAddModelOffset(end, end - 1, true);
+//                    length = end - start;
+//                }
+//            }
             selection = newSel;
             //Only the caller can set the sticky column, e.g. in the case of an up/down motion.
             caretListener.disable();

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
 import net.sourceforge.vrapper.eclipse.interceptor.EditorInfo;
 import net.sourceforge.vrapper.eclipse.ui.CaretUtils;
 import net.sourceforge.vrapper.log.VrapperLog;
@@ -538,16 +539,25 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void paintControl(PaintEvent e) {
-            // This painter only works for Vrapper selections.
-            if (selection == null) {
+            if ( ! VrapperPlugin.isVrapperEnabled()) {
                 return;
             }
-            GC gc = e.gc;
             StyledText text = textViewer.getTextWidget();
+            if (text.getSelectionCount() == 0) {
+                return;
+            }
+            // Forces caret visibility for blockwise mode: normally it is disabled all the time.
+            // Regular visual modes should have it visible anyway.
+            // [TODO] Maybe check if this blockwise visual selection is done through vrapper. A user
+            // dragging a block selection using the mouse might get confused.
+            text.getCaret().setVisible(true);
+//            GC gc = e.gc;
 //            text.getCaret().
 //            gc.getDevice().getSystemColor(SWT.)
-            gc.setForeground(text.getForeground());
-            Position to = selection.getTo();
+//            gc.setForeground(text.getForeground());
+//            gc.setForeground(text.getSelectionBackground());
+//            gc.setBackground(text.getSelectionForeground());
+            Position to = getSelection().getTo();
             boolean isInclusive = Selection.INCLUSIVE.equals(configuration.get(Options.SELECTION));
             int offset = to.getViewOffset();
             if (textViewer.getDocument().getLength() == to.getModelOffset() && isInclusive) {
@@ -558,9 +568,10 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
                 caretBounds = text.getTextBounds(offset, offset);
             } else {
                 Point visualOffset = text.getLocationAtOffset(offset);
-                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, 1, text.getLineHeight(offset));
+                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, 2, text.getLineHeight(offset));
             }
-            gc.drawRectangle(caretBounds);
+//            gc.fillRectangle(caretBounds);
+            text.getCaret().setBounds(caretBounds);
         }
     }
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
@@ -77,7 +77,7 @@ public class EclipsePlatform implements Platform {
         this.localConfiguration = new SimpleLocalConfiguration(configProviders, sharedConfiguration);
         this.bufferAndTabService = bufferAndTabService;
         textContent = new EclipseTextContent(sourceViewer);
-        cursorAndSelection = new EclipseCursorAndSelection(localConfiguration, partInfo, sourceViewer, textContent);
+        cursorAndSelection = new EclipseCursorAndSelection(vrapperModeRecorder, localConfiguration, partInfo, sourceViewer, textContent);
         fileService = new EclipseFileService(abstractTextEditor);
         viewportService = new EclipseViewportService(sourceViewer);
         serviceProvider = new EclipseServiceProvider(abstractTextEditor);

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/ui/CaretUtils.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/ui/CaretUtils.java
@@ -11,60 +11,60 @@ import org.eclipse.swt.widgets.Caret;
 public class CaretUtils {
 
     public static Caret createCaret(CaretType caretType, StyledText styledText) {
-	    GC gc = new GC(styledText);
+        GC gc = new GC(styledText);
         final int width = gc.getFontMetrics().getAverageCharWidth();
         final int height = gc.getFontMetrics().getHeight();
         gc.dispose();
 
-	    EvilCaret caret = new EvilCaret(styledText, SWT.NULL, height);
+        EvilCaret caret = new EvilCaret(styledText, SWT.NULL, height);
 
-	    switch (caretType) {
-		case VERTICAL_BAR:
-			caret.setSize(2, height);
-			break;
-		case RECTANGULAR:
-		    caret.setSize(width, height);
-		    break;
-		case LEFT_SHIFTED_RECTANGULAR:
-		    caret.setSize(width, height);
-		    caret.setShiftLeft(true);
-		    break;
-		case HALF_RECT:
-		    caret.setSize(width, height / 2);
-			break;
-		case UNDERLINE:
-		    caret.setSize(width, 3);
-		    break;
-	    }
-
-	    return caret;
-	}
-
-    // XXX: this is EXTREMALLY evil :->
-	private static final class EvilCaret extends Caret {
-        private final int height;
-        private boolean shiftLeft;
-
-        private EvilCaret(Canvas parent, int style, int height) {
-            super(parent, style);
-            this.height = height;
+        switch (caretType) {
+        case VERTICAL_BAR:
+            caret.setSize(2, height);
+            break;
+        case RECTANGULAR:
+            caret.setSize(width, height);
+            break;
+        case LEFT_SHIFTED_RECTANGULAR:
+            caret.setSize(width, height);
+            caret.setShiftLeft(true);
+            break;
+        case HALF_RECT:
+            caret.setSize(width, height / 2);
+            break;
+        case UNDERLINE:
+            caret.setSize(width, 3);
+            break;
         }
 
-        @Override protected void checkSubclass() { }
+        return caret;
+    }
+
+    // XXX: this is EXTREMALLY evil :->
+    private static final class EvilCaret extends Caret {
+        private final int textHeight;
+        private boolean shiftLeft;
+
+        private EvilCaret(Canvas parent, int style, int textHeight) {
+            super(parent, style);
+            this.textHeight = textHeight;
+        }
+
+        @Override
+        protected void checkSubclass() {}
 
         @Override
         public void setLocation(int x, int y) {
-            if(shiftLeft) {
+            if (shiftLeft) {
                 x -= getSize().x;
             }
-        	super.setLocation(x, y + height - getSize().y);
+            // Caret is placed top-left above a character but underline and half-block need to be
+            // at the bottom. Fix this by offsetting with textHeight and correcting by size.
+            super.setLocation(x, y + textHeight - getSize().y);
         }
 
         private void setShiftLeft(boolean shift) {
             shiftLeft = shift;
         }
     }
-
-
-
 }


### PR DESCRIPTION
This is an experimental branch where I was testing out a fake caret so that you can see where Vrapper's caret is inside of a Visual Line or Visual Block selection (it paints in Visual mode too, but again, it's experimental).

@igrekster 
You can check it out when implementing Visual block's `o` or `O` commands, but it still needs work. For example, it doesn't clean up after itself (rendering artifacts), it doesn't paint a caret at the end of a line and it wraps characters so tightly that they might become hard to read (simply inverting a filled rectangle is not really supported through SWT, it warns about compatibility with Mac OS X). 