### PR TITLE
EXPERIMENTAL Blockwise swap

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwapBlockwiseSelectionSidesCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwapBlockwiseSelectionSidesCommand.java
@@ -1,0 +1,72 @@
+package net.sourceforge.vrapper.vim.commands;
+
+import net.sourceforge.vrapper.platform.CursorService;
+import net.sourceforge.vrapper.platform.TextContent;
+import net.sourceforge.vrapper.utils.LineInformation;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.StartEndTextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.Options;
+import net.sourceforge.vrapper.vim.commands.BlockWiseSelection.TextBlock;
+import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+
+public class SwapBlockwiseSelectionSidesCommand extends CountIgnoringNonRepeatableCommand {
+
+    private enum SwapMode {
+        DIAGONAL,
+        HORIZONTAL
+    };
+
+    final SwapMode mode;
+
+    public static final SwapBlockwiseSelectionSidesCommand DIAGONAL_INSTANCE
+        = new SwapBlockwiseSelectionSidesCommand(SwapMode.DIAGONAL);
+    public static final SwapBlockwiseSelectionSidesCommand HORIZONTAL_INSTANCE
+        = new SwapBlockwiseSelectionSidesCommand(SwapMode.HORIZONTAL);
+
+    private SwapBlockwiseSelectionSidesCommand(SwapMode mode) {
+        this.mode = mode;
+    }
+
+    public void execute(EditorAdaptor editorAdaptor) {
+        final CursorService cs = editorAdaptor.getCursorService();
+        final TextContent mc = editorAdaptor.getModelContent();
+        final Selection sel = editorAdaptor.getSelection();
+        if (sel.getModelLength() == 1) {
+            // do nothing
+            return;
+        }
+        // Swap from and to offsets.
+        Position newStartPos = sel.getTo();
+        Position newEndPos =   sel.getFrom();
+        switch (mode) {
+        case DIAGONAL:
+            // Swapping to and from is enough for the diagonal swap.
+            break;
+        case HORIZONTAL:
+            final int startVOffs = cs.getVisualOffset(sel.getStart());
+            final int endVOffs = cs.getVisualOffset(sel.getEnd());
+            final LineInformation startLine = mc.getLineInformationOfOffset(sel.getStart().getModelOffset());
+            final LineInformation endLine = mc.getLineInformationOfOffset(sel.getEnd().getModelOffset());
+            // Swap visual offsets of the start and end position, but keep them
+            // on the same line.
+            newStartPos = cs.getPositionByVisualOffset(startLine.getNumber(), endVOffs);
+            newEndPos   = cs.getPositionByVisualOffset(endLine.getNumber(),   startVOffs);
+            // Clamp by the last character on the line if there is no characters
+            // at the visual offset (mimics VIM behaviour).
+            if (newStartPos == null) {
+                final int lineEndOfs = Math.max(startLine.getEndOffset() - 1,
+                        startLine.getBeginOffset());
+                newStartPos = cs.newPositionForModelOffset(lineEndOfs);
+            }
+            if (newEndPos == null) {
+                final int lineEndOfs = Math.max(endLine.getEndOffset() - 1,
+                        endLine.getBeginOffset());
+                newEndPos = cs.newPositionForModelOffset(lineEndOfs);
+            }
+            break;
+        }
+        MotionCommand.gotoAndChangeViewPort(editorAdaptor, newEndPos, StickyColumnPolicy.ON_CHANGE);
+        editorAdaptor.setSelection(sel.reset(editorAdaptor, newStartPos, newEndPos));
+    }
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
@@ -41,6 +41,7 @@ import net.sourceforge.vrapper.vim.commands.ReplaceCommand;
 import net.sourceforge.vrapper.vim.commands.Selection;
 import net.sourceforge.vrapper.vim.commands.SelectionBasedTextOperationCommand;
 import net.sourceforge.vrapper.vim.commands.SwapCaseCommand;
+import net.sourceforge.vrapper.vim.commands.SwapBlockwiseSelectionSidesCommand;
 import net.sourceforge.vrapper.vim.commands.motions.BlockSelectionMotion;
 import net.sourceforge.vrapper.vim.commands.motions.Motion;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
@@ -291,6 +292,8 @@ public class BlockwiseVisualMode extends AbstractVisualMode {
                 leafBind('c', change),
                 leafBind('C', change),
                 leafBind('s', change),
+                leafBind('o', (Command) SwapBlockwiseSelectionSidesCommand.DIAGONAL_INSTANCE),
+                leafBind('O', (Command) SwapBlockwiseSelectionSidesCommand.HORIZONTAL_INSTANCE),
                 leafBind('I', (Command) new BlockwiseChangeToInsertModeCommand(new MotionCommand(bol), InsertModeType.INSERT)),
                 leafBind('A', (Command) new BlockwiseChangeToInsertModeCommand(new MotionCommand(eol), InsertModeType.APPEND)),
                 leafBind('~', swapCase),

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/LinewiseVisualMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/LinewiseVisualMode.java
@@ -3,7 +3,9 @@ package net.sourceforge.vrapper.vim.modes;
 import static net.sourceforge.vrapper.keymap.StateUtils.union;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafBind;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafCtrlBind;
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafState;
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.state;
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.transitionState;
 import net.sourceforge.vrapper.keymap.State;
 import net.sourceforge.vrapper.keymap.vim.VisualMotionState;
 import net.sourceforge.vrapper.utils.CaretType;
@@ -19,6 +21,9 @@ import net.sourceforge.vrapper.vim.commands.LineWiseSelection;
 import net.sourceforge.vrapper.vim.commands.Selection;
 import net.sourceforge.vrapper.vim.commands.SwapLinewiseSelectionSidesCommand;
 import net.sourceforge.vrapper.vim.commands.VisualMotionCommand;
+import net.sourceforge.vrapper.vim.commands.motions.Motion;
+import net.sourceforge.vrapper.vim.commands.motions.MoveRightAcrossLines;
+import net.sourceforge.vrapper.vim.commands.motions.MoveWordEndLeft;
 import net.sourceforge.vrapper.vim.commands.motions.SearchResultMotion;
 
 public class LinewiseVisualMode extends AbstractVisualMode {
@@ -43,7 +48,15 @@ public class LinewiseVisualMode extends AbstractVisualMode {
 
     @Override
     protected VisualMotionState getVisualMotionState() {
-        return new VisualMotionState(motions());
+        @SuppressWarnings("unchecked")
+        State<Motion> motions = union(
+                leafState(' ', MoveRightAcrossLines.INSTANCE_BEHIND_CHAR),
+                transitionState('g',
+                        state(
+                            // Included here for similarity to Visual mode, doesn't affect linewise.
+                            leafBind('e', MoveWordEndLeft.INSTANCE_VISUAL))),
+                motions());
+        return new VisualMotionState(motions);
     }
 
     public String getName() {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
 import net.sourceforge.vrapper.eclipse.interceptor.EditorInfo;
 import net.sourceforge.vrapper.eclipse.ui.CaretUtils;
 import net.sourceforge.vrapper.log.VrapperLog;
@@ -474,16 +475,25 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void paintControl(PaintEvent e) {
-            // This painter only works for Vrapper selections.
-            if (selection == null) {
+            if ( ! VrapperPlugin.isVrapperEnabled()) {
                 return;
             }
-            GC gc = e.gc;
             StyledText text = textViewer.getTextWidget();
+            if (text.getSelectionCount() == 0) {
+                return;
+            }
+            // Forces caret visibility for blockwise mode: normally it is disabled all the time.
+            // Regular visual modes should have it visible anyway.
+            // [TODO] Maybe check if this blockwise visual selection is done through vrapper. A user
+            // dragging a block selection using the mouse might get confused.
+            text.getCaret().setVisible(true);
+//            GC gc = e.gc;
 //            text.getCaret().
 //            gc.getDevice().getSystemColor(SWT.)
-            gc.setForeground(text.getForeground());
-            Position to = selection.getTo();
+//            gc.setForeground(text.getForeground());
+//            gc.setForeground(text.getSelectionBackground());
+//            gc.setBackground(text.getSelectionForeground());
+            Position to = getSelection().getTo();
             boolean isInclusive = Selection.INCLUSIVE.equals(configuration.get(Options.SELECTION));
             int offset = to.getViewOffset();
             if (textViewer.getDocument().getLength() == to.getModelOffset() && isInclusive) {
@@ -494,9 +504,10 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
                 caretBounds = text.getTextBounds(offset, offset);
             } else {
                 Point visualOffset = text.getLocationAtOffset(offset);
-                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, 1, text.getLineHeight(offset));
+                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, 2, text.getLineHeight(offset));
             }
-            gc.drawRectangle(caretBounds);
+//            gc.fillRectangle(caretBounds);
+            text.getCaret().setBounds(caretBounds);
         }
     }
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -32,10 +32,13 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.resource.JFaceColors;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.ITextViewerExtension2;
 import org.eclipse.jface.text.ITextViewerExtension5;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -43,6 +46,8 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.swt.custom.CaretEvent;
 import org.eclipse.swt.custom.CaretListener;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.GC;
@@ -84,6 +89,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
     private final EclipseTextContent textContent;
     private int averageCharWidth;
     private CaretType caretType = null;
+    private FakeCaretPainter fakeCaretPainter;
 
     public EclipseCursorAndSelection(final Configuration configuration,
             EditorInfo editorInfo, final ITextViewer textViewer, final EclipseTextContent textContent) {
@@ -106,8 +112,10 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
         caretListener = new StickyColumnUpdater();
         marks = new HashMap<String, org.eclipse.jface.text.Position>();
         changeList = new ArrayList<org.eclipse.jface.text.Position>();
+        fakeCaretPainter = new FakeCaretPainter();
         textViewer.getTextWidget().addSelectionListener(selectionChangeListener);
         textViewer.getTextWidget().addCaretListener(caretListener);
+        textViewer.getTextWidget().addPaintListener(fakeCaretPainter);
         textViewer.getSelectionProvider().addSelectionChangedListener(selectionChangeListener);
         textViewer.getDocument().addPositionCategory(POSITION_CATEGORY_NAME);
     }
@@ -460,6 +468,36 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
             enabled = false;
         }
 
+    }
+
+    private final class FakeCaretPainter implements PaintListener {
+
+        @Override
+        public void paintControl(PaintEvent e) {
+            // This painter only works for Vrapper selections.
+            if (selection == null) {
+                return;
+            }
+            GC gc = e.gc;
+            StyledText text = textViewer.getTextWidget();
+//            text.getCaret().
+//            gc.getDevice().getSystemColor(SWT.)
+            gc.setForeground(text.getForeground());
+            Position to = selection.getTo();
+            boolean isInclusive = Selection.INCLUSIVE.equals(configuration.get(Options.SELECTION));
+            int offset = to.getViewOffset();
+            if (textViewer.getDocument().getLength() == to.getModelOffset() && isInclusive) {
+                offset--;
+            }
+            Rectangle caretBounds;
+            if (isInclusive) {
+                caretBounds = text.getTextBounds(offset, offset);
+            } else {
+                Point visualOffset = text.getLocationAtOffset(offset);
+                caretBounds = new Rectangle(visualOffset.x, visualOffset.y, 1, text.getLineHeight(offset));
+            }
+            gc.drawRectangle(caretBounds);
+        }
     }
 
     @Override


### PR DESCRIPTION
Got the swaps working similar to VIM.
The fake cursor was working fine except on `TAB` characters where it became wide and on empty lines where it becomes thin. A workaround for the wide case could be simply to copy the original with from `caret.getBounds()`.