### PR TITLE
Fix insert -> temporary command mode switch

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/AbstractCommandParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/AbstractCommandParser.java
@@ -273,7 +273,10 @@ public abstract class AbstractCommandParser {
         } else if (parsedCommand == null) {
             editor.changeModeSafely(NormalMode.NAME);
         } else {
-            editor.changeModeSafely(NormalMode.NAME, new ExecuteCommandHint.OnEnter(parsedCommand));
+            editor.changeModeSafely(
+                    // Return to the last mode in the case of a temporary mode switch.
+                    isFromVisual ? NormalMode.NAME : editor.getLastModeName(),
+                    new ExecuteCommandHint.OnEnter(parsedCommand));
             // Only do this AFTER changing the mode, Eclipse commands might still use the selection!
             editor.setSelection(null);
         }


### PR DESCRIPTION
Change to the previous editor mode upon exiting a temporary command mode
initiated with `A-O` from insert mode.