### PR TITLE
Fix #613: Add support for `o` and `O` in blockwise-visual

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwapBlockwiseSelectionSidesCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwapBlockwiseSelectionSidesCommand.java
@@ -1,0 +1,72 @@
+package net.sourceforge.vrapper.vim.commands;
+
+import net.sourceforge.vrapper.platform.CursorService;
+import net.sourceforge.vrapper.platform.TextContent;
+import net.sourceforge.vrapper.utils.LineInformation;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.StartEndTextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.Options;
+import net.sourceforge.vrapper.vim.commands.BlockWiseSelection.TextBlock;
+import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+
+public class SwapBlockwiseSelectionSidesCommand extends CountIgnoringNonRepeatableCommand {
+
+    private enum SwapMode {
+        DIAGONAL,
+        HORIZONTAL
+    };
+
+    final SwapMode mode;
+
+    public static final SwapBlockwiseSelectionSidesCommand DIAGONAL_INSTANCE
+        = new SwapBlockwiseSelectionSidesCommand(SwapMode.DIAGONAL);
+    public static final SwapBlockwiseSelectionSidesCommand HORIZONTAL_INSTANCE
+        = new SwapBlockwiseSelectionSidesCommand(SwapMode.HORIZONTAL);
+
+    private SwapBlockwiseSelectionSidesCommand(SwapMode mode) {
+        this.mode = mode;
+    }
+
+    public void execute(EditorAdaptor editorAdaptor) {
+        final CursorService cs = editorAdaptor.getCursorService();
+        final TextContent mc = editorAdaptor.getModelContent();
+        final Selection sel = editorAdaptor.getSelection();
+        if (sel.getModelLength() == 1) {
+            // do nothing
+            return;
+        }
+        // Swap from and to offsets.
+        Position newStartPos = sel.getTo();
+        Position newEndPos =   sel.getFrom();
+        switch (mode) {
+        case DIAGONAL:
+            // Swapping to and from is enough for the diagonal swap.
+            break;
+        case HORIZONTAL:
+            final int startVOffs = cs.getVisualOffset(sel.getStart());
+            final int endVOffs = cs.getVisualOffset(sel.getEnd());
+            final LineInformation startLine = mc.getLineInformationOfOffset(sel.getStart().getModelOffset());
+            final LineInformation endLine = mc.getLineInformationOfOffset(sel.getEnd().getModelOffset());
+            // Swap visual offsets of the start and end position, but keep them
+            // on the same line.
+            newStartPos = cs.getPositionByVisualOffset(startLine.getNumber(), endVOffs);
+            newEndPos   = cs.getPositionByVisualOffset(endLine.getNumber(),   startVOffs);
+            // Clamp by the last character on the line if there is no characters
+            // at the visual offset (mimics VIM behaviour).
+            if (newStartPos == null) {
+                final int lineEndOfs = Math.max(startLine.getEndOffset() - 1,
+                        startLine.getBeginOffset());
+                newStartPos = cs.newPositionForModelOffset(lineEndOfs);
+            }
+            if (newEndPos == null) {
+                final int lineEndOfs = Math.max(endLine.getEndOffset() - 1,
+                        endLine.getBeginOffset());
+                newEndPos = cs.newPositionForModelOffset(lineEndOfs);
+            }
+            break;
+        }
+        MotionCommand.gotoAndChangeViewPort(editorAdaptor, newEndPos, StickyColumnPolicy.ON_CHANGE);
+        editorAdaptor.setSelection(sel.reset(editorAdaptor, newStartPos, newEndPos));
+    }
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwapBlockwiseSelectionSidesCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwapBlockwiseSelectionSidesCommand.java
@@ -52,15 +52,15 @@ public class SwapBlockwiseSelectionSidesCommand extends CountIgnoringNonRepeatab
             // on the same line.
             newStartPos = cs.getPositionByVisualOffset(startLine.getNumber(), endVOffs);
             newEndPos   = cs.getPositionByVisualOffset(endLine.getNumber(),   startVOffs);
-            // Clamp by the last character on the line if there is no characters
+            // Clamp by the last character on the line if there are no characters
             // at the visual offset (mimics VIM behaviour).
             if (newStartPos == null) {
-                final int lineEndOfs = Math.max(startLine.getEndOffset() - 1,
+                final int lineEndOfs = Math.max(startLine.getEndOffset(),
                         startLine.getBeginOffset());
                 newStartPos = cs.newPositionForModelOffset(lineEndOfs);
             }
             if (newEndPos == null) {
-                final int lineEndOfs = Math.max(endLine.getEndOffset() - 1,
+                final int lineEndOfs = Math.max(endLine.getEndOffset(),
                         endLine.getBeginOffset());
                 newEndPos = cs.newPositionForModelOffset(lineEndOfs);
             }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/BlockwiseVisualMode.java
@@ -40,6 +40,7 @@ import net.sourceforge.vrapper.vim.commands.ReplaceCommand;
 import net.sourceforge.vrapper.vim.commands.Selection;
 import net.sourceforge.vrapper.vim.commands.SelectionBasedTextOperationCommand;
 import net.sourceforge.vrapper.vim.commands.SwapCaseCommand;
+import net.sourceforge.vrapper.vim.commands.SwapBlockwiseSelectionSidesCommand;
 import net.sourceforge.vrapper.vim.commands.motions.BlockSelectionMotion;
 import net.sourceforge.vrapper.vim.commands.motions.Motion;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
@@ -290,6 +291,8 @@ public class BlockwiseVisualMode extends AbstractVisualMode {
                 leafBind('c', change),
                 leafBind('C', change),
                 leafBind('s', change),
+                leafBind('o', (Command) SwapBlockwiseSelectionSidesCommand.DIAGONAL_INSTANCE),
+                leafBind('O', (Command) SwapBlockwiseSelectionSidesCommand.HORIZONTAL_INSTANCE),
                 leafBind('I', (Command) new BlockwiseChangeToInsertModeCommand(new MotionCommand(bol), InsertModeType.INSERT)),
                 leafBind('A', (Command) new BlockwiseChangeToInsertModeCommand(new MotionCommand(eol), InsertModeType.APPEND)),
                 leafBind('~', swapCase),


### PR DESCRIPTION
With `VisualCaretPanter` merged in I've rebased my implementation for `o` and `O` for the blockwise-visual mode.