### PR TITLE
Open fold on confirm substitution

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/ConfirmSubstitutionMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/ConfirmSubstitutionMode.java
@@ -133,6 +133,10 @@ public class ConfirmSubstitutionMode extends AbstractMode {
             return;
         }
 
+        if (result.getLeftBound().getViewOffset() < 0) {
+            editorAdaptor.getViewportService().exposeModelPosition(result.getLeftBound());
+        }
+        
         editorAdaptor.setPosition(result.getLeftBound(), StickyColumnPolicy.NEVER);
         if(doHighlight) {
             //force match to be visible (move scrollbars)


### PR DESCRIPTION
Expose model position if it is not visible.

Fix #686