### PR TITLE
Line completion fixes

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -59,7 +59,6 @@ import net.sourceforge.vrapper.vim.modes.BlockwiseVisualMode;
 import net.sourceforge.vrapper.vim.modes.ConfirmSubstitutionMode;
 import net.sourceforge.vrapper.vim.modes.ContentAssistMode;
 import net.sourceforge.vrapper.vim.modes.EditorMode;
-import net.sourceforge.vrapper.vim.modes.InsertExpandMode;
 import net.sourceforge.vrapper.vim.modes.InsertMode;
 import net.sourceforge.vrapper.vim.modes.LinewiseVisualMode;
 import net.sourceforge.vrapper.vim.modes.ModeSwitchHint;
@@ -208,7 +207,6 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
                 new TempLinewiseVisualMode(self),
                 new BlockwiseVisualMode(self),
                 new InsertMode(self),
-                new InsertExpandMode(self),
                 new ReplaceMode(self),
                 new CommandLineMode(self),
                 new SearchMode(self),

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/InsertMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/InsertMode.java
@@ -9,6 +9,7 @@ import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.state;
 import static net.sourceforge.vrapper.vim.commands.CommandWrappers.dontRepeat;
 import static net.sourceforge.vrapper.vim.commands.CommandWrappers.repeat;
 import static net.sourceforge.vrapper.vim.commands.CommandWrappers.seq;
+
 import net.sourceforge.vrapper.keymap.EmptyState;
 import net.sourceforge.vrapper.keymap.KeyStroke;
 import net.sourceforge.vrapper.keymap.SpecialKey;
@@ -355,9 +356,6 @@ public class InsertMode extends AbstractMode {
             // move to "paste register" mode, but don't actually perform the
             // "leave insert mode" operations
             editorAdaptor.changeModeSafely(PasteRegisterMode.NAME, RESUME_ON_MODE_ENTER);
-            return true;
-        } else if (stroke.equals(CTRL_X)) {
-            editorAdaptor.changeModeSafely(InsertExpandMode.NAME, RESUME_ON_MODE_ENTER);
             return true;
         } else if (stroke.equals(CTRL_O)) {
             // perform a single NormalMode command then return to InsertMode

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -137,5 +137,13 @@
       </type>
 
    </extension>
+   <extension
+         point="net.sourceforge.vrapper.eclipse.psmp">
+      <mode-provider
+            id="net.sourceforge.vrapper.eclipse.mode-provider1"
+            name="net.sourceforge.vrapper.eclipse.mode-provider1"
+            provider-class="net.sourceforge.vrapper.eclipse.modes.EclipseSpecificModeProvider">
+      </mode-provider>
+   </extension>
 </plugin>
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
@@ -14,16 +14,19 @@ import net.sourceforge.vrapper.eclipse.commands.GoToMarkCommand;
 import net.sourceforge.vrapper.eclipse.commands.ListTabsCommand;
 import net.sourceforge.vrapper.eclipse.commands.TabNewCommand;
 import net.sourceforge.vrapper.eclipse.commands.ToggleFoldingCommand;
+import net.sourceforge.vrapper.eclipse.modes.InsertExpandMode;
 import net.sourceforge.vrapper.keymap.EmptyState;
 import net.sourceforge.vrapper.keymap.KeyMapInfo;
 import net.sourceforge.vrapper.keymap.SpecialKey;
 import net.sourceforge.vrapper.keymap.State;
 import net.sourceforge.vrapper.keymap.StateUtils;
 import net.sourceforge.vrapper.vim.VimConstants;
+import net.sourceforge.vrapper.vim.commands.ChangeModeCommand;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.DeselectAllCommand;
 import net.sourceforge.vrapper.vim.commands.LeaveVisualModeCommand;
 import net.sourceforge.vrapper.vim.commands.TextObject;
+import net.sourceforge.vrapper.vim.modes.InsertMode;
 
 /**
  * Provides eclipse-specific bindings for command based modes.
@@ -121,6 +124,7 @@ public class EclipseSpecificStateProvider extends AbstractEclipseSpecificStatePr
     @Override
     protected State<Command> insertModeBindings() {
     	return state(
+    		leafCtrlBind('x', dontRepeat(new ChangeModeCommand(InsertExpandMode.NAME, InsertMode.RESUME_ON_MODE_ENTER))),
     		leafCtrlBind('n', dontRepeat(editText("hippieCompletion"))),
     		leafCtrlBind('p', dontRepeat(editText("hippieCompletion")))
     	);

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/EclipseSpecificModeProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/EclipseSpecificModeProvider.java
@@ -1,0 +1,22 @@
+package net.sourceforge.vrapper.eclipse.modes;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.vrapper.platform.AbstractPlatformSpecificModeProvider;
+import net.sourceforge.vrapper.platform.PlatformSpecificModeProvider;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.modes.EditorMode;
+
+public class EclipseSpecificModeProvider extends AbstractPlatformSpecificModeProvider
+        implements PlatformSpecificModeProvider {
+
+    public EclipseSpecificModeProvider() {
+        super("Vrapper-Eclipse Specific Modes Provider");
+    }
+
+    @Override
+    public List<EditorMode> getModes(EditorAdaptor editorAdaptor) {
+        return Collections.singletonList((EditorMode) new InsertExpandMode(editorAdaptor));
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/EclipseSpecificModeProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/EclipseSpecificModeProvider.java
@@ -6,6 +6,7 @@ import java.util.List;
 import net.sourceforge.vrapper.platform.AbstractPlatformSpecificModeProvider;
 import net.sourceforge.vrapper.platform.PlatformSpecificModeProvider;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.modes.EditorMode;
 
 public class EclipseSpecificModeProvider extends AbstractPlatformSpecificModeProvider
@@ -16,7 +17,7 @@ public class EclipseSpecificModeProvider extends AbstractPlatformSpecificModePro
     }
 
     @Override
-    public List<EditorMode> getModes(EditorAdaptor editorAdaptor) {
+    public List<EditorMode> getModes(EditorAdaptor editorAdaptor) throws CommandExecutionException {
         return Collections.singletonList((EditorMode) new InsertExpandMode(editorAdaptor));
     }
 }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
@@ -1,4 +1,4 @@
-package net.sourceforge.vrapper.vim.modes;
+package net.sourceforge.vrapper.eclipse.modes;
 
 import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.ctrlKey;
 
@@ -13,6 +13,7 @@ import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+import net.sourceforge.vrapper.vim.modes.InsertMode;
 
 /**
  * See :help ins-completion 
@@ -21,7 +22,7 @@ import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
  */
 public class InsertExpandMode extends InsertMode {
 
-    public static final String NAME = "insert expand mode";
+    public static final String NAME = InsertExpandMode.class.getName();
     public static final String DISPLAY_NAME = "^X mode (^L)";
     private static final Pattern indentPattern = Pattern.compile("(^\\s*)\\S*");
     private String lastIndent = "";

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
@@ -7,11 +7,18 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.ui.texteditor.ITextEditor;
+
+import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
+import net.sourceforge.vrapper.eclipse.interceptor.UnknownEditorException;
 import net.sourceforge.vrapper.keymap.KeyStroke;
 import net.sourceforge.vrapper.platform.TextContent;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
 import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
 import net.sourceforge.vrapper.vim.modes.InsertMode;
 
@@ -25,6 +32,7 @@ public class InsertExpandMode extends InsertMode {
     public static final String NAME = InsertExpandMode.class.getName();
     public static final String DISPLAY_NAME = "^X mode (^L)";
     private static final Pattern indentPattern = Pattern.compile("(^\\s*)\\S*");
+    private ITextEditor textEditor;
     private String lastIndent = "";
     private String lastPrefix = "";
     private String lastSuffix = "";
@@ -32,8 +40,24 @@ public class InsertExpandMode extends InsertMode {
     private int lastIndex = 0;
     private int lastLineNo = 0;
 
-    public InsertExpandMode(EditorAdaptor editorAdaptor) {
+    public InsertExpandMode(EditorAdaptor editorAdaptor) throws CommandExecutionException {
         super(editorAdaptor);
+        InputInterceptor interceptor;
+        try {
+            interceptor = VrapperPlugin.getDefault().findActiveInterceptor();
+        } catch (VrapperPlatformException e) {
+            CommandExecutionException e2 =  new CommandExecutionException(
+                    "Failed to initialize InsertExpandMode.");
+            e2.initCause(e);
+            throw e2;
+        } catch (UnknownEditorException e) {
+            CommandExecutionException e2 = new CommandExecutionException(
+                    "Failed to initialize InsertExpandMode.");
+            e2.initCause(e);
+            throw e2;
+        }
+        assert editorAdaptor.equals(interceptor.getEditorAdaptor());
+        textEditor = interceptor.getPlatform().getUnderlyingEditor();
     }
 
     @Override

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
@@ -90,6 +90,7 @@ public class InsertExpandMode extends InsertMode {
         }
         else {
             //return to insert mode if any other key pressed
+			clearLineMatches();
             editorAdaptor.changeModeSafely(InsertMode.NAME, InsertMode.RESUME_ON_MODE_ENTER);
             return super.handleKey(stroke);
         }
@@ -174,5 +175,15 @@ public class InsertExpandMode extends InsertMode {
 		} catch (BadLocationException e) {
 			throw new VrapperPlatformException("Failed to find line completions", e);
 		}
+	}
+
+	private void clearLineMatches() {
+		// will be incremented to 1 on first iteration
+		lastIndex = 0;
+		lastMatches.clear();
+		lastLineNo = 0;
+		lastIndent = "";
+		lastPrefix = "";
+		lastSuffix = "";
 	}
 }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
@@ -102,7 +102,7 @@ public class InsertExpandMode extends InsertMode {
         int cursorOffset = cursorPos.getModelOffset();
         LineInformation lineInfo = model.getLineInformationOfOffset(cursorOffset);
         String line = model.getText(lineInfo.getBeginOffset(), lineInfo.getLength());
-        if(lastLineNo != lineInfo.getNumber() || ! line.startsWith(lastIndent + lastPrefix)) {
+		if (lastLineNo != lineInfo.getNumber() || (!line.equals(lastIndent + lastPrefix) && lastIndex == 0)) {
 			rebuildLineMatches(cursorOffset - lineInfo.getBeginOffset(), line, lineInfo.getNumber());
         }
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/modes/InsertExpandMode.java
@@ -157,7 +157,7 @@ public class InsertExpandMode extends InsertMode {
 		IRegion matchLine;
 		String matchText;
 		Set<String> alreadySeen = new HashSet<String>();
-		alreadySeen.add(line); // ignore current text
+		alreadySeen.add(lastPrefix); // ignore current text
 		alreadySeen.add(""); // ignore empty lines
 		try {
 			for (IDocument model : hippieDocuments) {


### PR DESCRIPTION
I found some problems and inconsistencies in line completion (**C-x** **C-l**):
* it uses the current editor in opposite to vim and hippie completion (**C-n** / **C-p**) which use all opened buffers
* when search term is narrowed it uses the same list of lines
* cannot go backward which is painful when list is bigger

This pull request is kind of draft how it could be done using existing Eclipse facilities. This way it could be consistent with Hippie completion. If that approach is viable i could make it conform all coding standards and so but first want to know if it will not fail quickly :)