### PR TITLE
Allow new major versions of CDT

### DIFF
--- a/plugins/languages/net.sourceforge.vrapper.eclipse.cdt.feature/feature.xml
+++ b/plugins/languages/net.sourceforge.vrapper.eclipse.cdt.feature/feature.xml
@@ -693,7 +693,7 @@ Public License instead of this License.  But first, please read
    <requires>
       <import plugin="net.sourceforge.vrapper.eclipse" version="0.63.20160104" match="greaterOrEqual"/>
       <import feature="net.sourceforge.vrapper" version="0.63.20160104"/>
-      <import plugin="org.eclipse.cdt.ui" version="5.1.1" match="compatible"/>
+      <import plugin="org.eclipse.cdt.ui" version="5.1.1" match="greaterOrEqual"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
I'm using nightly CDT and the developers have bumped `org.eclipse.cdt.ui` version to `6.0.0`. This resulted in a conflict with our CDT extension (`compatible` mode doesn't allow for major version change).
I've tested the CDT key bindings  and they seem to work fine with the new version.