### PR TITLE
Added tests for normal mode to test S

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
@@ -118,6 +118,31 @@ public class NormalModeTests extends CommandTestCase {
 		verify(adaptor).changeMode(eq(InsertMode.NAME), (ModeSwitchHint[]) any());
 	}
 
+	@Test public void test_S_middle_of_line() throws CommandExecutionException {
+		checkCommand(forKeySeq("S"),
+				"Al",'a'," ma kota",
+				"",'\n',"");
+		assertYanked(ContentType.LINES, "Ala ma kota\n");
+		verify(adaptor).changeMode(eq(InsertMode.NAME), (ModeSwitchHint[]) any());
+	}
+
+
+	@Test public void test_S_beginning_of_line() throws CommandExecutionException {
+		checkCommand(forKeySeq("S"),
+				"",'A',"la ma kota",
+				"",'\n',"");
+		assertYanked(ContentType.LINES, "Ala ma kota\n");
+		verify(adaptor).changeMode(eq(InsertMode.NAME), (ModeSwitchHint[]) any());
+	}
+	
+	@Test public void test_S_end_of_line() throws CommandExecutionException {
+		checkCommand(forKeySeq("S"),
+				"Ala ma kot",'a',"",
+				"",'\n',"");
+		assertYanked(ContentType.LINES, "Ala ma kota\n");
+		verify(adaptor).changeMode(eq(InsertMode.NAME), (ModeSwitchHint[]) any());
+	}	
+
 	@Test public void test_X() {
 		checkCommand(forKeySeq("X"),
 				"",'a'," ma kota",

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/NormalModeTests.java
@@ -142,6 +142,13 @@ public class NormalModeTests extends CommandTestCase {
 		assertYanked(ContentType.LINES, "Ala ma kota\n");
 		verify(adaptor).changeMode(eq(InsertMode.NAME), (ModeSwitchHint[]) any());
 	}	
+	
+	@Test public void test_S_middle_of_file() throws CommandExecutionException {
+		checkCommand(forKeySeq("S"), "First Line\nSec", 'o', "nd Line\nThird Line",
+				"First Line\n", '\n', "Third Line");
+		assertYanked(ContentType.LINES, "Second Line\n");
+		verify(adaptor).changeMode(eq(InsertMode.NAME), (ModeSwitchHint[]) any());
+	}
 
 	@Test public void test_X() {
 		checkCommand(forKeySeq("X"),


### PR DESCRIPTION
Hi, added some tests for normal mode. While developing these tests, saw a small difference in vrapper and vim.

The difference is when there is only 1 line in the file, and you press 'S' in normal mode, in vim, there is still only 1 line in the file, whereas in vrapper there are 2 lines after that. Don't know if this is a bug worth fixing, but just bringing it to your attention. If you fix that bug, these tests will also have to change.