### PR TITLE
Fix paste-after of recorded macro

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MacroTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MacroTests.java
@@ -97,6 +97,42 @@ public class MacroTests extends CommandTestCase {
 				"Ala bla", 'h', " kota");
 	}
 	
+	@Test public void testYankMacro() {
+		//yank text into a register to be used later as a macro
+		checkCommand(forKeySeq("\"byW"),
+				"Ala ",'c', "wfoo<ESC> ma kota",
+				"Ala ",'c', "wfoo<ESC> ma kota");
+
+		//execute the register as a macro, changing the word to foo
+		checkCommand(forKeySeq("@b"),
+				"Ala ",'m', "a kota",
+				"Ala foo", ' ' , "kota");
+	}
+	
+	@Test public void testPasteMacroBefore() {
+		//define macro
+		checkCommand(forKeySeq("qacwfoo<ESC>q"),
+				"Ala ",'m', "a kota",
+				"Ala fo", 'o', " kota");
+
+		//paste before from a register filled by recording a macro
+		checkCommand(forKeySeq("\"aP"),
+				"Ala ",'m', "a kota",
+				"Ala cwfoo<ESC", '>' , "ma kota");
+	}
+	
+	@Test public void testPasteMacroAfter() {
+		//define macro
+		checkCommand(forKeySeq("qacwfoo<ESC>q"),
+				"Ala ",'m', "a kota",
+				"Ala fo", 'o', " kota");
+
+		//paste after from a register filled by recording a macro
+		checkCommand(forKeySeq("\"ap"),
+				"Ala ",'m', "a kota",
+				"Ala mcwfoo<ESC", '>' , "a kota");
+	}
+	
 	@Test public void testRegisters() {
 		//yank a word into the "a" register
 		checkCommand(forKeySeq("\"ayw"),

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PasteAfterCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PasteAfterCommand.java
@@ -50,6 +50,7 @@ public class PasteAfterCommand extends CountAwareCommand {
             }
             break;
         case TEXT:
+        case KEY_SEQUENCE:
             offset = Math.min(line.getEndOffset(), offset + 1);
             position = offset + text.length() * count;
             // Move cursor back, unless we should be after the pasted text or if line is empty.


### PR DESCRIPTION
After a macro was recorded, executing a paste-after ('p') would not
paste register contents.

The problem was that the ContentType of the register was set to KEY_SEQUENCE which was falling into the default case of the switch statement.

Commit fixes the issue and adds tests for it.