### PR TITLE
Added support for Doxygen (//!) and C# (///) style single-line comments to FormatOperation

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/VimUtils.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/VimUtils.java
@@ -1,8 +1,10 @@
 package net.sourceforge.vrapper.utils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -329,6 +331,10 @@ public class VimUtils {
 
     public static final <T> Set<T> set(final T... content) {
         return Collections.unmodifiableSet(new HashSet<T>(Arrays.asList(content)));
+    }
+    
+    public static final <T> List<T> list(final T... content) {
+    	return Collections.unmodifiableList(new ArrayList<T>(Arrays.asList(content)));
     }
 
     public static SearchResult wrapAroundSearch(final EditorAdaptor vim, final Search search,

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/FormatOperation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/FormatOperation.java
@@ -195,7 +195,7 @@ public class FormatOperation extends AbstractLinewiseOperation {
 	 */
 	private class CommentedLine {
 	
-		public final Set<String> SINGLE_LINE_COMMENTS = VimUtils.set("//", "#", "*");
+		public final List<String> SINGLE_LINE_COMMENTS = VimUtils.list("//!", "///", "//", "#", "*");
 		public static final String MULTI_LINE_START = "/*";
 		public static final String MULTI_LINE_END = "*/";
 	


### PR DESCRIPTION
Added support for Doxygen (//!) and C# (///) style single-line comments to FormatOperation. Recognized single line comment strings now have a defined order in which they are processed.