### PR TITLE
Modify print information behavior

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/utils/TestTextContent.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/utils/TestTextContent.java
@@ -93,6 +93,12 @@ public class TestTextContent implements TextContent {
         return lines;
     }
 
+    @Override
+    public int getNumberOfLines(TextRange range) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
     public String getText(int index, int length) {
     	return buffer.substring(index, index + length);
     }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/TextContent.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/TextContent.java
@@ -32,6 +32,11 @@ public interface TextContent {
     int getNumberOfLines();
 
     /**
+     * @return number of lines which are occupied by a given text range.
+     */
+    int getNumberOfLines(TextRange range);
+
+    /**
      * @param index
      *            start of the text to replace.
      * @param length
@@ -68,6 +73,13 @@ public interface TextContent {
      * @return the specified substring of the text.
      */
     String getText(int index, int length);
+
+    /**
+     * Retrieves the complete text.
+     *
+     * @return the text.
+     */
+    String getText();
 
     String getText(TextRange range);
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/UnmodifiableTextContentDecorator.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/UnmodifiableTextContentDecorator.java
@@ -51,6 +51,11 @@ public class UnmodifiableTextContentDecorator implements TextContent {
     }
 
     @Override
+    public int getNumberOfLines(TextRange range) {
+        return textContent.getNumberOfLines(range);
+    }
+
+    @Override
     public void replace(int index, int length, String s) {
         if (allowChanges()) {
             textContent.replace(index, length, s);
@@ -69,6 +74,11 @@ public class UnmodifiableTextContentDecorator implements TextContent {
         if (allowChanges()) {
             textContent.smartInsert(s);
         }
+    }
+
+    @Override
+    public String getText() {
+        return textContent.getText();
     }
 
     @Override

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintOffsetInformation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintOffsetInformation.java
@@ -62,9 +62,13 @@ public class PrintOffsetInformation implements Command {
 
         int totalBytes = 0;
         int byteNumber = 0;
+        int totalChars = 0;
+        int charNumber = 0;
         try {
             totalBytes = modelText.getBytes("UTF-8").length;
+            totalChars = modelText.toCharArray().length;
             byteNumber = byteOffset.getBytes("UTF-8").length;
+            charNumber = byteOffset.toCharArray().length;
         } catch (UnsupportedEncodingException e) {
             VrapperLog.info(e.getMessage());
         }
@@ -77,6 +81,7 @@ public class PrintOffsetInformation implements Command {
                           "Col " + colNumber + " of " + lineLength + "; "
                         + "Line " + (modelLine.getNumber() + 1) + " of " + modelContent.getNumberOfLines() + "; "
                         + "Word " + wordNumber + " of " + totalWords + "; "
+                        + (totalChars != totalBytes ? ("Char " + charNumber + " of " + totalChars + "; ") : "")
                         + "Byte " + byteNumber + " of " + totalBytes + "; "
                         + "Position M " + modelOffset + " / " + position.getViewOffset() + " V; "
                         + "line " + modelLine.getNumber() + " / " + viewLine.getNumber() + " view line; "

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintOffsetInformation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintOffsetInformation.java
@@ -1,8 +1,16 @@
 package net.sourceforge.vrapper.vim.commands;
 
+import java.io.UnsupportedEncodingException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.CursorService;
+import net.sourceforge.vrapper.platform.TextContent;
 import net.sourceforge.vrapper.platform.UserInterfaceService;
 import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.VimUtils;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 
 public class PrintOffsetInformation implements Command {
@@ -29,13 +37,49 @@ public class PrintOffsetInformation implements Command {
         Position position = editorAdaptor.getPosition();
         UserInterfaceService service = editorAdaptor.getUserInterfaceService();
         int visualOffset = editorAdaptor.getCursorService().getVisualOffset(position);
-        service.setInfoSet(true);
-        LineInformation modelLine = editorAdaptor.getModelContent().getLineInformationOfOffset(position.getModelOffset());
+        CursorService cursorService = editorAdaptor.getCursorService();
+        TextContent modelContent = editorAdaptor.getModelContent();
+        int modelOffset = position.getModelOffset();
+        LineInformation modelLine = modelContent.getLineInformationOfOffset(modelOffset);
         LineInformation viewLine = editorAdaptor.getViewContent().getLineInformationOfOffset(position.getViewOffset());
-        service.setLastCommandResultValue("Position M " + position.getModelOffset() + " / "
-        + position.getViewOffset() + " V; line " + modelLine.getNumber() + " / "
-                + viewLine.getNumber() + " view line; horizontal offset " + visualOffset);
-        // TODO Print extra information about selection in case of visual mode.
-        // Better off in a seperate command or sub-mode
+
+        Pattern pattern = Pattern.compile("[\\S]+");
+        int totalWords = 0;
+        String modelText = modelContent.getText();
+        Matcher matcher = pattern.matcher(modelText);
+        String wholeWord = VimUtils.getWordUnderCursor(editorAdaptor, true);
+
+        int wordNumber = 0;
+        String byteOffset = "";
+        while (matcher.find()) {
+            totalWords++;
+            if (matcher.group().equals(wholeWord) && matcher.start() <= modelOffset && modelOffset <= matcher.end()) {
+                wordNumber = totalWords;
+                byteOffset = modelContent.getText(0, position.addModelOffset(1).getModelOffset());
+            }
+            matcher.start();
+        }
+
+        int totalBytes = 0;
+        int byteNumber = 0;
+        try {
+            totalBytes = modelText.getBytes("UTF-8").length;
+            byteNumber = byteOffset.getBytes("UTF-8").length;
+        } catch (UnsupportedEncodingException e) {
+            VrapperLog.info(e.getMessage());
+        }
+
+        service.setInfoSet(true);
+        int colNumber = VimUtils.calculateColForPosition(modelContent, position) + 1;
+        int lineLength = VimUtils.calculateColForPosition(modelContent, cursorService.newPositionForModelOffset(modelLine.getEndOffset()));
+
+        service.setLastCommandResultValue(
+                          "Col " + colNumber + " of " + lineLength + "; "
+                        + "Line " + (modelLine.getNumber() + 1) + " of " + modelContent.getNumberOfLines() + "; "
+                        + "Word " + wordNumber + " of " + totalWords + "; "
+                        + "Byte " + byteNumber + " of " + totalBytes + "; "
+                        + "Position M " + modelOffset + " / " + position.getViewOffset() + " V; "
+                        + "line " + modelLine.getNumber() + " / " + viewLine.getNumber() + " view line; "
+                        + "horizontal offset " + visualOffset);
     }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintTextRangeInformation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintTextRangeInformation.java
@@ -54,9 +54,13 @@ public class PrintTextRangeInformation implements Command {
         
         int selectedBytes = 0;
         int totalBytes = 0;
+        int selectedChars = 0;
+        int totalChars = 0;
         try {
             selectedBytes = rangeText.getBytes("UTF-8").length;
+            selectedChars = rangeText.toCharArray().length;
             totalBytes = contentText.getBytes("UTF-8").length;
+            totalChars = contentText.toCharArray().length;
         } catch (UnsupportedEncodingException e) {
             VrapperLog.info(e.getMessage());
         }
@@ -65,6 +69,7 @@ public class PrintTextRangeInformation implements Command {
         service.setLastCommandResultValue("Selected " 
                         + selectedLines + " of " + totalLines + " Lines; "
                         + selectedWords + " of " + totalWords + " Words; "
+                        + (totalChars != totalBytes ? (selectedChars + " of " + totalChars + " Chars; ") : "")
                         + selectedBytes + " of " + totalBytes + " Bytes");
     }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintTextRangeInformation.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/PrintTextRangeInformation.java
@@ -1,0 +1,70 @@
+package net.sourceforge.vrapper.vim.commands;
+
+import java.io.UnsupportedEncodingException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.TextContent;
+import net.sourceforge.vrapper.platform.UserInterfaceService;
+import net.sourceforge.vrapper.utils.TextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+public class PrintTextRangeInformation implements Command {
+
+    public static final Command INSTANCE = new PrintTextRangeInformation();
+
+    @Override
+    public Command withCount(int count) {
+        return this;
+    }
+
+    @Override
+    public int getCount() {
+        return NO_COUNT_GIVEN;
+    }
+
+    @Override
+    public Command repetition() {
+        return null;
+    }
+
+    @Override
+    public void execute(EditorAdaptor editorAdaptor) throws CommandExecutionException {
+        UserInterfaceService service = editorAdaptor.getUserInterfaceService();
+        TextContent modelContent = editorAdaptor.getModelContent();
+
+        Selection range = editorAdaptor.getSelection();
+        TextRange region = range.getRegion(editorAdaptor, NO_COUNT_GIVEN);
+        Pattern pattern = Pattern.compile("[\\S]+");
+
+        String rangeText = modelContent.getText(region);
+        String contentText = modelContent.getText();
+
+        int selectedWords = 0;
+        Matcher matcher = pattern.matcher(rangeText);
+        while (matcher.find()) selectedWords++;
+
+        int totalWords = 0;
+        matcher = pattern.matcher(contentText);
+        while (matcher.find()) totalWords++;
+
+        int selectedLines = modelContent.getNumberOfLines(range);
+        int totalLines = modelContent.getNumberOfLines();
+        
+        int selectedBytes = 0;
+        int totalBytes = 0;
+        try {
+            selectedBytes = rangeText.getBytes("UTF-8").length;
+            totalBytes = contentText.getBytes("UTF-8").length;
+        } catch (UnsupportedEncodingException e) {
+            VrapperLog.info(e.getMessage());
+        }
+
+        service.setInfoSet(true);
+        service.setLastCommandResultValue("Selected " 
+                        + selectedLines + " of " + totalLines + " Lines; "
+                        + selectedWords + " of " + totalWords + " Words; "
+                        + selectedBytes + " of " + totalBytes + " Bytes");
+    }
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/AbstractVisualMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/AbstractVisualMode.java
@@ -37,7 +37,7 @@ import net.sourceforge.vrapper.vim.commands.InsertShiftWidth;
 import net.sourceforge.vrapper.vim.commands.JoinVisualLinesCommand;
 import net.sourceforge.vrapper.vim.commands.LeaveVisualModeCommand;
 import net.sourceforge.vrapper.vim.commands.PasteOperation;
-import net.sourceforge.vrapper.vim.commands.PrintOffsetInformation;
+import net.sourceforge.vrapper.vim.commands.PrintTextRangeInformation;
 import net.sourceforge.vrapper.vim.commands.ReplaceCommand;
 import net.sourceforge.vrapper.vim.commands.Selection;
 import net.sourceforge.vrapper.vim.commands.SelectionBasedTextOperationCommand;
@@ -207,7 +207,7 @@ public abstract class AbstractVisualMode extends CommandBasedMode {
         final Command joinLines = JoinVisualLinesCommand.INSTANCE;
         final Command joinLinesDumbWay = JoinVisualLinesCommand.DUMB_INSTANCE;
         final Command findFile = VisualFindFileCommand.INSTANCE;
-        final Command printOffsetInfo = PrintOffsetInformation.INSTANCE;
+        final Command printTextRanteInformation = PrintTextRangeInformation.INSTANCE;
         final State<Command> visualMotions = getVisualMotionState();
         final State<Command> visualTextObjects = new VisualTextObjectState(
                                         editorAdaptor.getTextObjectProvider());
@@ -234,7 +234,7 @@ public abstract class AbstractVisualMode extends CommandBasedMode {
                 leafBind('>', shiftRight),
                 leafBind('<', shiftLeft),
                 transitionBind('g',
-                        leafCtrlBind('g', printOffsetInfo),
+                        leafCtrlBind('g', printTextRanteInformation),
                         // Always switch back to visual mode to show these text objects
                         leafBind('n', (Command) new ChangeToVisualModeCommand(VisualMode.NAME,
                                 new VisualMotionCommand(SearchResultMotion.NEXT_END))),

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseTextContent.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseTextContent.java
@@ -68,8 +68,22 @@ public class EclipseTextContent {
             return textViewer.getDocument().getNumberOfLines();
         }
 
+        public int getNumberOfLines(TextRange range) {
+            int offset = range.getStart().getModelOffset();
+            int length = range.getModelLength();
+            try {
+                return textViewer.getDocument().getNumberOfLines(offset, length);
+            } catch (BadLocationException e) {
+                throw new VrapperPlatformException("Failed to get number of lines for M " + offset + " lenght " + length, e);
+            }
+        }
+
         public int getTextLength() {
             return textViewer.getDocument().getLength();
+        }
+
+        public String getText() {
+            return textViewer.getDocument().get();
         }
 
         public String getText(int index, int length) {
@@ -145,8 +159,17 @@ public class EclipseTextContent {
             return textViewer.getTextWidget().getLineCount();
         }
 
+        public int getNumberOfLines(TextRange range) {
+            // TODO get viewSide number of lines
+            return modelSide.getNumberOfLines(range);
+        }
+
         public int getTextLength() {
             return textViewer.getTextWidget().getCharCount();
+        }
+
+        public String getText() {
+            return textViewer.getTextWidget().getText();
         }
 
         public String getText(int index, int length) {


### PR DESCRIPTION
I hope I'm on the right track here but if I'm not, please let me know.  I added two methods in `TextContent` that I believed were necessary to implement this:
- getNumberOfLines(TextRange) -> number of lines for Range
- getText() -> Text of complete document

I Created a separate command to print info on `TextRange`: `PrintTextRangeInformation` The previous behaviour of `PrintOffsetInformation` was preserved in the end of the info message to avoid breaking the old functionality.

Fix #724 
