### PR TITLE
Allow default vrapperrc location to be overriden

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -253,16 +253,26 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
         }
         try {
             configuration.setListenersEnabled(false);
-            String filename = CONFIG_FILE_NAME;
-            final File homeDir = new File(System.getProperty("user.home"));
-            File config = new File(homeDir, filename);
-            if( ! config.exists()) { //if no .vrapperrc, look for _vrapperrc
-                filename = WINDOWS_CONFIG_FILE_NAME;
-                config =  new File(homeDir, filename);
+            // Allow user to override default vrapperrc location by passing in alternate name
+            String overrideVrapperRcFile = System.getProperty("vrapper.vrapperrc");
+            boolean alternateRCLoaded = false;
+            
+            // sourceConfigurationFile method will resolve relatively to user home dir
+            if (overrideVrapperRcFile != null && overrideVrapperRcFile.trim().length() > 0) {
+                alternateRCLoaded =  sourceConfigurationFile(overrideVrapperRcFile.trim());
+                if ( ! alternateRCLoaded) {
+                    VrapperLog.error("Failed to load alternate vrapperrc [" + overrideVrapperRcFile + "]");
+                }
             }
-
-            if (config.exists()) {
-                sourceConfigurationFile(filename);
+            if ( ! alternateRCLoaded) {
+                String filename = CONFIG_FILE_NAME;
+                if ( ! sourceConfigurationFile(filename)) { //if no .vrapperrc, look for _vrapperrc
+                    filename = WINDOWS_CONFIG_FILE_NAME;
+                    if ( ! sourceConfigurationFile(filename)) {
+                        VrapperLog.info("No " + CONFIG_FILE_NAME + " or " + WINDOWS_CONFIG_FILE_NAME
+                                + " found.");
+                    }
+                } 
             }
         } finally {
             configuration.setListenersEnabled(true);
@@ -783,7 +793,7 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
                                 } else {
                                     currentMode.handleKey(next);
                                 }
-                            } 
+                            }
                         } finally {
                             if (keyStrokeTranslator.didMappingSucceed()) {
                                 mappingStack.pop();


### PR DESCRIPTION
It might be interesting to use a different vrapperrc location when testing a different version of vrapper or reproducing a problem.

This change will look for a system property called `vrapper.vrapperrc` which will be used as location for the vrapperrc. This can be a filename, relative to the user's homedir, or it can be an absolute filepath.

I chose to make this a pull request seeing how we're close to our bi-monthly release date.