### PR TITLE
Eclipse command plugs

### DIFF
--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/SpecialKey.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/SpecialKey.java
@@ -10,7 +10,11 @@ public enum SpecialKey {
 	 */
 	LEADER,
 	/**
-	 * <b>NOTE</b>: this is reserved for PlugKeyStroke instances, it should never be used by the
+	 * Special key which is always sent before a sequence of characters identifying a plugin
+	 * function.
+	 * <p>
+	 * <b>NOTE</b>: this is reserved for PlugKeyStroke instances, it should never be used
+	 * by the
 	 * input logic.
 	 */
 	PLUG;

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/vim/AbstractPlugState.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/vim/AbstractPlugState.java
@@ -1,0 +1,45 @@
+package net.sourceforge.vrapper.keymap.vim;
+
+import net.sourceforge.vrapper.keymap.KeyStroke;
+import net.sourceforge.vrapper.keymap.SpecialKey;
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.Transition;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+import net.sourceforge.vrapper.vim.RemappedKeyStroke;
+
+/**
+ * This abstract state detects <code>Plug</code> keystrokes and extracts their id for handling.
+ */
+public abstract class AbstractPlugState<T> implements State<T> {
+
+    @Override
+    public Transition<T> press(KeyStroke key) {
+        if (SpecialKey.PLUG == key.getSpecialKey()) {
+            PlugKeyStroke plug;
+            if (key instanceof RemappedKeyStroke) {
+                key = (PlugKeyStroke) ((RemappedKeyStroke)key).unwrap();
+            }
+            if (key instanceof PlugKeyStroke) {
+                plug = (PlugKeyStroke) key;
+            } else {
+                throw new VrapperPlatformException("Bad usage of PLUG key found, key is instance "
+                        + "of " + key.getClass().getName() + " whereas "
+                        + PlugKeyStroke.class.getName() + " was expected.");
+            }
+            if (plug.getId() == null || plug.getId().trim().length() == 0) {
+                throw new VrapperPlatformException("Bad usage of PLUG key found, id is null, empty"
+                        + " or solely whitespace.");
+            } else {
+                return press(plug.getId());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Override this method to handle plugs. The id is guaranteed to be more than whitespace.
+     * @return a {@link Transition} if the plug key was mapped or <code>null</code> if the id is
+     *     not recognized.
+     */
+    public abstract Transition<T> press(String id);
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/vim/VisualTextObjectState.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/vim/VisualTextObjectState.java
@@ -1,6 +1,7 @@
 package net.sourceforge.vrapper.keymap.vim;
 
 import net.sourceforge.vrapper.keymap.ConvertingState;
+import net.sourceforge.vrapper.keymap.State;
 import net.sourceforge.vrapper.utils.Function;
 import net.sourceforge.vrapper.vim.TextObjectProvider;
 import net.sourceforge.vrapper.vim.commands.Command;
@@ -14,9 +15,12 @@ public class VisualTextObjectState extends ConvertingState<Command, TextObject> 
             return new SelectTextObjectCommand(arg);
         }
     };
-    
+
     public VisualTextObjectState(TextObjectProvider provider) {
         super(converter, provider.textObjects());
     }
 
+    public VisualTextObjectState(State<TextObject> textObjects) {
+        super(converter, textObjects);
+    }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/RemappedKeyStroke.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/RemappedKeyStroke.java
@@ -78,4 +78,11 @@ public class RemappedKeyStroke implements KeyStroke {
     public boolean isVirtual() {
         return true;
     }
+
+    public KeyStroke unwrap() {
+        if (delegate instanceof RemappedKeyStroke) {
+            return ((RemappedKeyStroke)delegate).unwrap();
+        }
+        return delegate;
+    }
 }

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -145,5 +145,13 @@
             provider-class="net.sourceforge.vrapper.eclipse.modes.EclipseSpecificModeProvider">
       </mode-provider>
    </extension>
+   <extension
+         point="net.sourceforge.vrapper.eclipse.pstop">
+      <textobject-provider
+            id="net.sourceforge.vrapper.eclipse.textobject-provider"
+            name="net.sourceforge.vrapper.eclipse.textobject-provider"
+            provider-class="net.sourceforge.vrapper.eclipse.keymap.EclipseTextObjectProvider">
+      </textobject-provider>
+   </extension>
 </plugin>
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommand.java
@@ -4,6 +4,8 @@ import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.AbstractCommand;
 import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.LeaveVisualModeCommand;
 import net.sourceforge.vrapper.vim.commands.MultipleExecutionCommand;
 
 import org.eclipse.core.commands.ParameterizedCommand;
@@ -17,6 +19,7 @@ public class EclipseCommand extends AbstractCommand {
 
     private final String action;
     private final boolean async;
+    private boolean fromVisualMode;
 
     public EclipseCommand(String action) {
         this.action = action;
@@ -28,8 +31,15 @@ public class EclipseCommand extends AbstractCommand {
         this.async = async;
     }
 
-    public void execute(EditorAdaptor editorAdaptor) {
+    public void execute(EditorAdaptor editorAdaptor) throws CommandExecutionException {
+        if (fromVisualMode) {
+            editorAdaptor.rememberLastActiveSelection();
+        }
         doIt(1, action, editorAdaptor, async);
+
+        if (fromVisualMode) {
+            LeaveVisualModeCommand.doIt(editorAdaptor);
+        }
     }
 
     public String getCommandName() {
@@ -84,6 +94,16 @@ public class EclipseCommand extends AbstractCommand {
 
     public Command withCount(int count) {
         return new MultipleExecutionCommand(count, this);
+    }
+
+    /**
+     * Mark this command as being executed in visual mode.
+     * Note that this does not need to be called when running a command from command line mode, in
+     * such a case the command line mode and normal mode will handle all the extra logic.
+     */
+    public Command fromVisualMode(boolean fromVisualMode) {
+        this.fromVisualMode = fromVisualMode;
+        return this;
     }
 
     public String toString() {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommand.java
@@ -35,7 +35,7 @@ public class EclipseCommand extends AbstractCommand {
         if (fromVisualMode) {
             editorAdaptor.rememberLastActiveSelection();
         }
-        doIt(1, action, editorAdaptor, async);
+        doIt(action, editorAdaptor, async);
 
         if (fromVisualMode) {
             LeaveVisualModeCommand.doIt(editorAdaptor);
@@ -59,7 +59,7 @@ public class EclipseCommand extends AbstractCommand {
         return display;
     }
 
-    public static void doIt(int count, final String action, EditorAdaptor editorAdaptor, boolean async) {
+    public static void doIt(final String action, EditorAdaptor editorAdaptor, boolean async) {
         final IHandlerService handlerService = editorAdaptor.getService(IHandlerService.class);
         final ICommandService commandService = editorAdaptor.getService(ICommandService.class);
         if (handlerService != null && commandService != null) {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandMotion.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandMotion.java
@@ -7,12 +7,12 @@ import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.motions.CountAwareMotion;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
 
-public class EclipseMoveCommand extends CountAwareMotion {
+public class EclipseCommandMotion extends CountAwareMotion {
 
     private final String motionName;
     private final BorderPolicy borderPolicy;
 
-    public EclipseMoveCommand(String motionName, BorderPolicy borderPolicy) {
+    public EclipseCommandMotion(String motionName, BorderPolicy borderPolicy) {
         this.motionName = motionName;
         this.borderPolicy = borderPolicy;
     }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandMotion.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandMotion.java
@@ -29,7 +29,12 @@ public class EclipseCommandMotion extends CountAwareMotion {
     @Override
     public Position destination(EditorAdaptor editorAdaptor, int count) {
         Position oldCarretOffset = editorAdaptor.getPosition();
-        EclipseCommand.doIt(count, motionName, editorAdaptor, false);
+        if (count == NO_COUNT_GIVEN) {
+            count = 1;
+        }
+        for (int i = 0; i < count; i++) {
+            EclipseCommand.doIt(motionName, editorAdaptor, false);
+        }
         Position newCarretOffset = editorAdaptor.getPosition();
         editorAdaptor.setPosition(oldCarretOffset, StickyColumnPolicy.ON_CHANGE);
         return newCarretOffset;

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandTextObject.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandTextObject.java
@@ -1,9 +1,9 @@
 package net.sourceforge.vrapper.eclipse.commands;
 
 import net.sourceforge.vrapper.platform.Configuration;
+import net.sourceforge.vrapper.platform.SelectionService;
 import net.sourceforge.vrapper.utils.ContentType;
 import net.sourceforge.vrapper.utils.Position;
-import net.sourceforge.vrapper.utils.StartEndTextRange;
 import net.sourceforge.vrapper.utils.TextRange;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.AbstractTextObject;
@@ -21,16 +21,21 @@ public class EclipseCommandTextObject extends AbstractTextObject {
     @Override
     public TextRange getRegion(EditorAdaptor editorAdaptor, int count)
             throws CommandExecutionException {
-        Position oldCarretOffset = editorAdaptor.getPosition();
         if (count == NO_COUNT_GIVEN) {
             count = 1;
         }
         for (int i = 0; i < count; i++) {
             EclipseCommand.doIt(commandName, editorAdaptor, false);
         }
+        TextRange result = editorAdaptor.getNativeSelection();
+        // For when the Eclipse command did not reset Vrapper's selection.
+        if (SelectionService.VRAPPER_SELECTION_ACTIVE.equals(result)) {
+            result = editorAdaptor.getSelection().getRegion(editorAdaptor, count);
+        }
+        // Update sticky column by repositioning cursor. SelectTextObjectCommand will set selection
         Position newCarretOffset = editorAdaptor.getPosition();
-        editorAdaptor.setPosition(oldCarretOffset, StickyColumnPolicy.ON_CHANGE);
-        return new StartEndTextRange(oldCarretOffset, newCarretOffset);
+        editorAdaptor.setPosition(newCarretOffset, StickyColumnPolicy.ON_CHANGE);
+        return result;
     }
 
     @Override

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandTextObject.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandTextObject.java
@@ -22,7 +22,12 @@ public class EclipseCommandTextObject extends AbstractTextObject {
     public TextRange getRegion(EditorAdaptor editorAdaptor, int count)
             throws CommandExecutionException {
         Position oldCarretOffset = editorAdaptor.getPosition();
-        EclipseCommand.doIt(count, commandName, editorAdaptor, false);
+        if (count == NO_COUNT_GIVEN) {
+            count = 1;
+        }
+        for (int i = 0; i < count; i++) {
+            EclipseCommand.doIt(commandName, editorAdaptor, false);
+        }
         Position newCarretOffset = editorAdaptor.getPosition();
         editorAdaptor.setPosition(oldCarretOffset, StickyColumnPolicy.ON_CHANGE);
         return new StartEndTextRange(oldCarretOffset, newCarretOffset);

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandTextObject.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseCommandTextObject.java
@@ -1,0 +1,36 @@
+package net.sourceforge.vrapper.eclipse.commands;
+
+import net.sourceforge.vrapper.platform.Configuration;
+import net.sourceforge.vrapper.utils.ContentType;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.StartEndTextRange;
+import net.sourceforge.vrapper.utils.TextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.AbstractTextObject;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+
+public class EclipseCommandTextObject extends AbstractTextObject {
+
+    private final String commandName;
+
+    public EclipseCommandTextObject(String commandId) {
+        commandName = commandId;
+    }
+
+    @Override
+    public TextRange getRegion(EditorAdaptor editorAdaptor, int count)
+            throws CommandExecutionException {
+        Position oldCarretOffset = editorAdaptor.getPosition();
+        EclipseCommand.doIt(count, commandName, editorAdaptor, false);
+        Position newCarretOffset = editorAdaptor.getPosition();
+        editorAdaptor.setPosition(oldCarretOffset, StickyColumnPolicy.ON_CHANGE);
+        return new StartEndTextRange(oldCarretOffset, newCarretOffset);
+    }
+
+    @Override
+    public ContentType getContentType(Configuration configuration) {
+        return ContentType.TEXT;
+    }
+
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseMotionPlugState.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseMotionPlugState.java
@@ -1,0 +1,33 @@
+package net.sourceforge.vrapper.eclipse.commands;
+
+import java.util.Locale;
+
+import net.sourceforge.vrapper.keymap.SimpleTransition;
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.Transition;
+import net.sourceforge.vrapper.keymap.UnionState;
+import net.sourceforge.vrapper.keymap.vim.AbstractPlugState;
+import net.sourceforge.vrapper.vim.commands.BorderPolicy;
+import net.sourceforge.vrapper.vim.commands.motions.Motion;
+
+public class EclipseMotionPlugState extends AbstractPlugState<Motion> {
+
+    public static final String MOTIONPREFIX = "(eclipse-motion:";
+    public static final State<Motion> INSTANCE = new EclipseMotionPlugState();
+
+    @Override
+    public Transition<Motion> press(String id) {
+        if (id.toLowerCase(Locale.ENGLISH).startsWith(MOTIONPREFIX)) {
+            // Clip off prefix and last ')'
+            String commandId = id.substring(MOTIONPREFIX.length(), id.length() -1);
+            return new SimpleTransition<Motion>(new EclipseCommandMotion(commandId, BorderPolicy.EXCLUSIVE));
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public State<Motion> union(State<Motion> other) {
+        return new UnionState<Motion>(this, other);
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipsePlugState.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipsePlugState.java
@@ -1,0 +1,41 @@
+package net.sourceforge.vrapper.eclipse.commands;
+
+import java.util.Locale;
+
+import net.sourceforge.vrapper.keymap.SimpleTransition;
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.Transition;
+import net.sourceforge.vrapper.keymap.UnionState;
+import net.sourceforge.vrapper.keymap.vim.AbstractPlugState;
+import net.sourceforge.vrapper.vim.commands.Command;
+
+public class EclipsePlugState extends AbstractPlugState<Command> {
+
+    public static final String COMMANDPREFIX = "(eclipse:";
+    public static final State<Command> INSTANCE = new EclipsePlugState(false);
+    public static final State<Command> VISUAL_INSTANCE = new EclipsePlugState(true);
+
+    private boolean fromVisual;
+
+    public EclipsePlugState(boolean fromVisual) {
+        this.fromVisual = fromVisual;
+    }
+
+    @Override
+    public Transition<Command> press(String id) {
+        if (id.toLowerCase(Locale.ENGLISH).startsWith(COMMANDPREFIX)) {
+            // Clip off prefix and last ')'
+            String commandId = id.substring(COMMANDPREFIX.length(), id.length() -1);
+            Command result;
+            return new SimpleTransition<Command>(
+                    new EclipseCommand(commandId).fromVisualMode(fromVisual));
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public State<Command> union(State<Command> other) {
+        return new UnionState<Command>(this, other);
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseTextObjectPlugState.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/EclipseTextObjectPlugState.java
@@ -1,0 +1,32 @@
+package net.sourceforge.vrapper.eclipse.commands;
+
+import java.util.Locale;
+
+import net.sourceforge.vrapper.keymap.SimpleTransition;
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.Transition;
+import net.sourceforge.vrapper.keymap.UnionState;
+import net.sourceforge.vrapper.keymap.vim.AbstractPlugState;
+import net.sourceforge.vrapper.vim.commands.TextObject;
+
+public class EclipseTextObjectPlugState extends AbstractPlugState<TextObject> {
+
+    public static final String TEXTOBJPREFIX = "(eclipse-textobj:";
+    public static final State<TextObject> INSTANCE = new EclipseTextObjectPlugState();
+
+    @Override
+    public Transition<TextObject> press(String id) {
+        if (id.toLowerCase(Locale.ENGLISH).startsWith(TEXTOBJPREFIX)) {
+            // Clip off prefix and last ')'
+            String commandId = id.substring(TEXTOBJPREFIX.length(), id.length() -1);
+            return new SimpleTransition<TextObject>(new EclipseCommandTextObject(commandId));
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public State<TextObject> union(State<TextObject> other) {
+        return new UnionState<TextObject>(this, other);
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/TabNewCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/TabNewCommand.java
@@ -32,6 +32,6 @@ public class TabNewCommand extends EclipseCommand {
     }
     
     public void execute(EditorAdaptor editorAdaptor) {
-        doIt(1, getCommandName(), editorAdaptor, true);
+        doIt(getCommandName(), editorAdaptor, true);
     }
 }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/ToggleFoldingCommand.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/commands/ToggleFoldingCommand.java
@@ -24,10 +24,10 @@ public class ToggleFoldingCommand extends CountIgnoringNonRepeatableCommand {
 	public void execute(EditorAdaptor editorAdaptor)
 			throws CommandExecutionException {
 		int before = editorAdaptor.getViewContent().getNumberOfLines();
-		EclipseCommand.doIt(Command.NO_COUNT_GIVEN, expandCmdId, editorAdaptor, false);
+		EclipseCommand.doIt(expandCmdId, editorAdaptor, false);
 		int after = editorAdaptor.getViewContent().getNumberOfLines();
 		if (before == after) {
-			EclipseCommand.doIt(Command.NO_COUNT_GIVEN, collapseCmdId, editorAdaptor, false);
+			EclipseCommand.doIt(collapseCmdId, editorAdaptor, false);
 		}
 	}
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseSpecificStateProvider.java
@@ -16,6 +16,7 @@ import java.util.EnumSet;
 import net.sourceforge.vrapper.eclipse.commands.ChangeTabCommand;
 import net.sourceforge.vrapper.eclipse.commands.EclipseMotionPlugState;
 import net.sourceforge.vrapper.eclipse.commands.EclipsePlugState;
+import net.sourceforge.vrapper.eclipse.commands.EclipseTextObjectPlugState;
 import net.sourceforge.vrapper.eclipse.commands.GoToMarkCommand;
 import net.sourceforge.vrapper.eclipse.commands.ListTabsCommand;
 import net.sourceforge.vrapper.eclipse.commands.TabNewCommand;
@@ -30,6 +31,7 @@ import net.sourceforge.vrapper.keymap.StateUtils;
 import net.sourceforge.vrapper.keymap.vim.SimpleKeyStroke;
 import net.sourceforge.vrapper.keymap.vim.GoThereState;
 import net.sourceforge.vrapper.keymap.vim.VisualMotionState;
+import net.sourceforge.vrapper.keymap.vim.VisualTextObjectState;
 import net.sourceforge.vrapper.vim.VimConstants;
 import net.sourceforge.vrapper.vim.commands.ChangeModeCommand;
 import net.sourceforge.vrapper.vim.commands.Command;
@@ -103,6 +105,7 @@ public class EclipseSpecificStateProvider extends AbstractEclipseSpecificStatePr
         State<Command> normalModeBindings = StateUtils.union(
             new GoThereState(EclipseMotionPlugState.INSTANCE),
             EclipsePlugState.INSTANCE,
+            new VisualTextObjectState(EclipseTextObjectPlugState.INSTANCE),
             state(
                 transitionBind('z',
                         leafBind('a', ToggleFoldingCommand.DEFAULTINSTANCE),

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseTextObjectProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/EclipseTextObjectProvider.java
@@ -1,0 +1,33 @@
+package net.sourceforge.vrapper.eclipse.keymap;
+
+import static net.sourceforge.vrapper.keymap.StateUtils.union;
+
+import net.sourceforge.vrapper.eclipse.commands.EclipseMotionPlugState;
+import net.sourceforge.vrapper.eclipse.commands.EclipseTextObjectPlugState;
+import net.sourceforge.vrapper.keymap.EmptyState;
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.vim.TextObjectState;
+import net.sourceforge.vrapper.platform.AbstractPlatformSpecificTextObjectProvider;
+import net.sourceforge.vrapper.vim.commands.DelimitedText;
+import net.sourceforge.vrapper.vim.commands.TextObject;
+
+public class EclipseTextObjectProvider extends AbstractPlatformSpecificTextObjectProvider {
+
+    @Override
+    public State<DelimitedText> delimitedTexts() {
+        return EmptyState.getInstance();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public State<TextObject> textObjects() {
+        return union(
+                new TextObjectState(EclipseMotionPlugState.INSTANCE),
+                EclipseTextObjectPlugState.INSTANCE);
+    }
+
+    @Override
+    public String getName() {
+        return "vrapper-eclipse-textobjects";
+    }
+}


### PR DESCRIPTION
I have been working exclusively in .NET these days which is why you no longer hear from me as often.

Anyway, the code in this pull request has been sitting on my workstation ever since the beginning of August waiting to be documented. It's a generalized alternative to @psporysz plugin in #752 so I'm hoping that someone else can give some starting pointers for documentation after the following examples for your `.vrapperrc`:

```
noremap \w <Plug>(eclipse-motion:org.eclipse.ui.edit.text.goto.wordNext)
noremap \b <Plug>(eclipse-motion:org.eclipse.ui.edit.text.goto.wordPrevious)
noremap \e <Plug>(eclipse-textobj:org.eclipse.jdt.ui.edit.text.java.select.enclosing)
noremap \l <Plug>(eclipse-textobj:org.eclipse.jdt.ui.edit.text.java.select.last)
```

To explain the first line: this will bind e.g. `\w` to Eclipse's native word-Next command and should do so for normal mode, visual mode and operator mode (the latter might not be as well-tested though).

What @psporysz would be really after though is `\e` - this will select the enclosing element in visual mode (entering visual mode if invoked from normal mode).

Counts work so you can also enter `3\w` to jump 3 words forward.

The only trouble I've thought of is that it doesn't offer exactly the same functionality of `:eclipseuiaction`, but so far it seems to work with the commands above. I always though that was for commands which show some kind of pop-up.

This code could be merged with `master` without too much trouble as it's passive until you trigger a `<Plug>` mapping whose id happens to start with `(eclipse-motion:`, though I figured I'd best present this first seeing how it has no documentation yet.