### PR TITLE
Vrapper-sneak Mk. II

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MotionTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/MotionTests.java
@@ -1,7 +1,7 @@
 package net.sourceforge.vrapper.core.tests.cases;
 
 import net.sourceforge.vrapper.core.tests.utils.CommandTestCase;
-import net.sourceforge.vrapper.vim.commands.motions.FindMotion;
+import net.sourceforge.vrapper.vim.commands.motions.FindCharMotion;
 import net.sourceforge.vrapper.vim.commands.motions.GoToLineMotion;
 import net.sourceforge.vrapper.vim.commands.motions.MethodDeclarationMotion;
 import net.sourceforge.vrapper.vim.commands.motions.Motion;
@@ -785,7 +785,7 @@ public class MotionTests extends CommandTestCase {
 
 	@Test
 	public void test_f_motionWorks() {
-	    Motion fa = new FindMotion('a', true, false);
+	    Motion fa = new FindCharMotion('a', true, false);
 	    checkMotion(fa,
 	            "",'A',"la ma kota",
 	            "Al",'a'," ma kota");
@@ -807,7 +807,7 @@ public class MotionTests extends CommandTestCase {
 
 	@Test
 	public void test_t_motionWorks() {
-	    Motion ta = new FindMotion('a', false, false);
+	    Motion ta = new FindCharMotion('a', false, false);
 	    checkMotion(ta,
 	            "",'A',"la ma kota",
 	            "A",'l',"a ma kota");
@@ -825,7 +825,7 @@ public class MotionTests extends CommandTestCase {
 
 	@Test
 	public void test_F_motionWorks() {
-	    Motion Fa = new FindMotion('a', true, true);
+	    Motion Fa = new FindCharMotion('a', true, true);
 	    checkMotion(Fa,
 	            "Ala ",'m',"a kota",
 	            "Al",'a'," ma kota");

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/utils/VimTestCase.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/utils/VimTestCase.java
@@ -18,6 +18,7 @@ import net.sourceforge.vrapper.platform.HistoryService;
 import net.sourceforge.vrapper.platform.KeyMapProvider;
 import net.sourceforge.vrapper.platform.Platform;
 import net.sourceforge.vrapper.platform.PlatformSpecificStateProvider;
+import net.sourceforge.vrapper.platform.PlatformVrapperLifecycleListener;
 import net.sourceforge.vrapper.platform.ServiceProvider;
 import net.sourceforge.vrapper.platform.UnderlyingEditorSettings;
 import net.sourceforge.vrapper.platform.UserInterfaceService;
@@ -131,7 +132,8 @@ public class VimTestCase {
     }
 
     protected void reloadEditorAdaptor() {
-        DefaultEditorAdaptor unwrapped = new DefaultEditorAdaptor(platform, registerManager, false);
+        DefaultEditorAdaptor unwrapped = new DefaultEditorAdaptor(platform, registerManager, false,
+                Collections.<PlatformVrapperLifecycleListener>emptyList());
         DefaultEditorAdaptor wrapped = spy(unwrapped);
         wrapped.__set_modes(wrapped);
         adaptor = wrapped;

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/vim/SimpleKeyStroke.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/keymap/vim/SimpleKeyStroke.java
@@ -103,7 +103,7 @@ public class SimpleKeyStroke implements KeyStroke {
         for (Modifier modifier : modifiers) {
             key = modifier.getShortId() + key;
         }
-        return "SimpleKeyStroke(" + key + ")";
+        return "Key(" + key + ")";
     }
 
     @Override

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/HighlightingService.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/HighlightingService.java
@@ -46,6 +46,8 @@ public interface HighlightingService {
     /**
      * Highlights given regions using Eclipse annotation type. This is faster than repeatedly
      * calling {@link #highlightRegion(String, String, TextRange)}.
+     * The implementation should do its best to make the order of the return value match the order
+     * of the input values.
      * @param type Eclipse annotation type.
      * @param name highlighting name.
      * @param region range of text to highlight.

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/PlatformVrapperLifecycleAdapter.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/PlatformVrapperLifecycleAdapter.java
@@ -1,0 +1,23 @@
+package net.sourceforge.vrapper.platform;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+/**
+ * Instances of this class are notified when a new EditorAdaptor instance is built.
+ * <p>Instances should not assume that this class is used as a singleton, preferably there should
+ * be no non-static variables in instances of this class.
+ */
+public abstract class PlatformVrapperLifecycleAdapter implements PlatformVrapperLifecycleListener {
+
+    @Override
+    public void editorInitialized(EditorAdaptor editorAdaptor, boolean enabled) {
+    }
+
+    @Override
+    public void editorConfigured(EditorAdaptor editorAdaptor, boolean enabled) {
+    }
+
+    @Override
+    public void editorClosing(EditorAdaptor editorAdaptor, boolean enabled) {
+    }
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/PlatformVrapperLifecycleListener.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/PlatformVrapperLifecycleListener.java
@@ -1,0 +1,21 @@
+package net.sourceforge.vrapper.platform;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+/**
+ * Instances of this interface are notified when a new EditorAdaptor instance is built.
+ * <p>Instances should not assume that this class is used as a singleton, preferably there should
+ * be no non-static variables in instances of this class.
+ * <p>Implementations are recommended to extend {@link PlatformVrapperLifecycleAdapter}.
+ */
+public interface PlatformVrapperLifecycleListener {
+
+    /** Run when an editor has just read its configuration but before extensions are added. */
+    public void editorConfigured(EditorAdaptor editorAdaptor, boolean enabled);
+
+    /** Run when Vrapper is fully initialized in an editor. */
+    public void editorInitialized(EditorAdaptor editorAdaptor, boolean enabled);
+
+    /** Called just before closing an editor. */
+    public void editorClosing(EditorAdaptor editorAdaptor, boolean enabled);
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/Reversible.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/Reversible.java
@@ -1,0 +1,16 @@
+package net.sourceforge.vrapper.utils;
+
+import net.sourceforge.vrapper.vim.commands.motions.ContinueFindingMotion;
+
+public interface Reversible<T> {
+    /** returns T copy which will move in the other direction (eg. Motion repeated by
+     * {@link ContinueFindingMotion}) compared to this one. This function should never return null.
+     */
+    T reverse();
+
+    /**
+     * While {@link #reverse()} can always return a copy for the reversed direction, this method
+     * identifies if the current instance will move backward or not.
+     */
+    boolean isBackward();
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/Search.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/Search.java
@@ -57,4 +57,49 @@ public class Search implements Reversible<Search> {
     public SearchOffset getSearchOffset() {
         return afterSearch;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (backward ? 1231 : 1237);
+        result = prime * result + (caseSensitive ? 1231 : 1237);
+        result = prime * result + ((keyword == null) ? 0 : keyword.hashCode());
+        result = prime * result + (regexSearch ? 1231 : 1237);
+        result = prime * result + (searchInSelection ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Search other = (Search) obj;
+        if (backward != other.backward)
+            return false;
+
+        // Check other fields
+        return equalsIgnoreDirection(other);
+    }
+
+    public boolean equalsIgnoreDirection(Search other) {
+        if (other == null)
+            return false;
+        if (caseSensitive != other.caseSensitive)
+            return false;
+        if (keyword == null) {
+            if (other.keyword != null)
+                return false;
+        } else if (!keyword.equals(other.keyword))
+            return false;
+        if (regexSearch != other.regexSearch)
+            return false;
+        if (searchInSelection != other.searchInSelection)
+            return false;
+        return true;
+    }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/Search.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/Search.java
@@ -1,6 +1,6 @@
 package net.sourceforge.vrapper.utils;
 
-public class Search {
+public class Search implements Reversible<Search> {
 
     private final String keyword;
     private final boolean backward;
@@ -27,6 +27,7 @@ public class Search {
         this.searchInSelection = searchInSelection;
     }
 
+    @Override
     public Search reverse() {
         return new Search(keyword, !backward, caseSensitive, afterSearch, regexSearch, searchInSelection);
     }
@@ -35,6 +36,7 @@ public class Search {
         return keyword;
     }
 
+    @Override
     public boolean isBackward() {
         return backward;
     }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/VimUtils.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/VimUtils.java
@@ -21,6 +21,7 @@ import net.sourceforge.vrapper.vim.Options;
 import net.sourceforge.vrapper.vim.VimConstants;
 import net.sourceforge.vrapper.vim.commands.Selection;
 import net.sourceforge.vrapper.vim.commands.Utils;
+import net.sourceforge.vrapper.vim.modes.ModeSwitchHint;
 
 
 /**
@@ -488,5 +489,27 @@ public class VimUtils {
         CursorService cursorService = adaptor.getCursorService();
         int originalPos = original.getModelOffset();
         return cursorService.shiftPositionForModelOffset(originalPos, delta, allowPastLastChar);
+    }
+
+    /**
+     * Find a mode switch hint of a specific type. Note that it is more efficient to simply loop
+     * over the arguments and write a tree of nested <code>if (x instanceof Y)</code> blocks when
+     * one wants to find multiple types of hints.
+     * @return the mode hint or <code>null</code>.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T findModeHint(Class<T> typeToFind, ModeSwitchHint...args) {
+        T result = null;
+        if (args.length >= 1 && typeToFind.isInstance(args[0])) {
+            result = (T) args[0];
+        }
+        int i = 1;
+        while (i < args.length && result == null) {
+            if (typeToFind.isInstance(args[i])) {
+                result = (T) args[i];
+            }
+            i++;
+        }
+        return result;
     }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/RemappedKeyStroke.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/RemappedKeyStroke.java
@@ -19,6 +19,8 @@ public class RemappedKeyStroke implements KeyStroke {
 
     public RemappedKeyStroke(KeyStroke delegate, boolean recursive) {
         super();
+        if (delegate == null)
+            throw new NullPointerException("Delegate cannot be null");
         this.delegate = delegate;
         this.recursive = recursive;
     }
@@ -53,16 +55,7 @@ public class RemappedKeyStroke implements KeyStroke {
 
     @Override
     public String toString() {
-        String key = getSpecialKey() == null ? Character.toString(getCharacter()) : getSpecialKey().toString();
-        EnumSet<Modifier> modifiers = EnumSet.copyOf(getModifiers());
-        modifiers.remove(Modifier.SHIFT);
-        if ((getSpecialKey() != null || getCharacter() == ' ') && withShiftKey()) {
-            key = "S-" + key;
-        }
-        for (Modifier modifier : modifiers) {
-            key = modifier.getShortId() + key;
-        }
-        return "RemappedKeyStroke(" + key + ")";
+        return "RemapKey(" + delegate.toString() + ")";
     }
 
     @Override

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/Adaptable.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/Adaptable.java
@@ -1,0 +1,15 @@
+package net.sourceforge.vrapper.vim.commands;
+
+/**
+ * Instances of this interface can be adapted to another representation. What representations are
+ * supported is specific for each instance and is currently not queryable.
+ */
+public interface Adaptable {
+    /**
+     * Tries to adapt the current instance to another type. Note that some state (like count values)
+     * might be missing in the adapted objects.
+     * 
+     * @return an object of the requested type or <code>null</code> if not possible.
+     */
+    public <T> T getAdapter(Class<T> type);
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/MotionCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/MotionCommand.java
@@ -12,6 +12,7 @@ import net.sourceforge.vrapper.utils.ViewPortInformation;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.Options;
 import net.sourceforge.vrapper.vim.commands.motions.Motion;
+import net.sourceforge.vrapper.vim.commands.motions.NavigatingMotion;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
 
 public class MotionCommand extends CountAwareCommand {
@@ -41,6 +42,11 @@ public class MotionCommand extends CountAwareCommand {
         Position previousPosition = editorAdaptor.getPosition();
         if (motion.isJump()) {
             cursorService.updateLastPosition();
+        }
+        // Store motion in case it's a more advanced next / reverse motion
+        NavigatingMotion navigatingMotion = motion.getAdapter(NavigatingMotion.class);
+        if (navigatingMotion != null) {
+            editorAdaptor.getRegisterManager().setLastNavigatingMotion(navigatingMotion.repetition());
         }
         final Position destination = motion.destination(editorAdaptor);
         gotoAndChangeViewPort(editorAdaptor, destination, motion.stickyColumnPolicy());

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SuspendVisualModeCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SuspendVisualModeCommand.java
@@ -1,0 +1,16 @@
+package net.sourceforge.vrapper.vim.commands;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+/** Remembers the last active selection for later use. */
+public class SuspendVisualModeCommand extends CountIgnoringNonRepeatableCommand {
+
+    public static final Command INSTANCE = new SuspendVisualModeCommand();
+
+    private SuspendVisualModeCommand() { /* NOP */ }
+
+    public void execute(EditorAdaptor editorAdaptor) throws CommandExecutionException {
+        // Only save selection when this command is executed - other commands call doIt() as well.
+        editorAdaptor.rememberLastActiveSelection();
+    }
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/AbstractMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/AbstractMotion.java
@@ -1,0 +1,18 @@
+package net.sourceforge.vrapper.vim.commands.motions;
+
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.BorderPolicy;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+
+public abstract class AbstractMotion implements Motion {
+    @Override
+    public int getCount() {
+        return NO_COUNT_GIVEN;
+    }
+
+    @Override
+    public <T> T getAdapter(Class<T> type) {
+        return null;
+    }
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/BlockSelectionMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/BlockSelectionMotion.java
@@ -13,7 +13,7 @@ import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.commands.Selection;
 
-public class BlockSelectionMotion implements Motion {
+public class BlockSelectionMotion extends AbstractMotion {
 
     public static final BlockSelectionMotion COLUMN_START = new BlockSelectionMotion(true);
     public static final BlockSelectionMotion COLUMN_END = new BlockSelectionMotion(false);
@@ -32,11 +32,6 @@ public class BlockSelectionMotion implements Motion {
     @Override
     public Motion withCount(final int count) {
         return this;
-    }
-
-    @Override
-    public int getCount() {
-        return NO_COUNT_GIVEN;
     }
 
     @Override
@@ -77,5 +72,4 @@ public class BlockSelectionMotion implements Motion {
     public boolean isJump() {
         return false;
     }
-
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
@@ -26,10 +26,10 @@ public class ContinueFindingMotion extends CountAwareMotion {
             throw new CommandExecutionException("no find to repeat");
         }
         if (reverse) {
-            findCharMotion = findCharMotion.reversed();
+            findCharMotion = findCharMotion.reverse();
         }
         borderPolicy = findCharMotion.borderPolicy();
-        Position dest = findCharMotion.destination(editorAdaptor, count);
+        Position dest = findCharMotion.withCount(count).destination(editorAdaptor);
         return dest;
     }
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
@@ -21,26 +21,26 @@ public class ContinueFindingMotion extends CountAwareMotion {
     @Override
     public Position destination(EditorAdaptor editorAdaptor, int count)
             throws CommandExecutionException {
-        FindMotion findMotion = editorAdaptor.getRegisterManager().getLastFindMotion();
-        if (findMotion == null) {
+        FindCharMotion findCharMotion = editorAdaptor.getRegisterManager().getLastFindCharMotion();
+        if (findCharMotion == null) {
             throw new CommandExecutionException("no find to repeat");
         }
         if (reverse) {
-            findMotion = findMotion.reversed();
+            findCharMotion = findCharMotion.reversed();
         }
-        borderPolicy = findMotion.borderPolicy();
-        Position dest = findMotion.destination(editorAdaptor, count);
+        borderPolicy = findCharMotion.borderPolicy();
+        Position dest = findCharMotion.destination(editorAdaptor, count);
         //If using 't' and the cursor is before the last match, destination()
         //will think this position is the next match and not move the cursor.
         //If this happens, move the cursor forward one (so it's on top of the
         //last match) and run destination() again.  If 'T', go back one.
-        if(!findMotion.upToTarget && editorAdaptor.getPosition().getModelOffset() == dest.getModelOffset()) {
-            int tweakOffset = findMotion.backwards ? -1 : 1;
+        if(!findCharMotion.upToTarget && editorAdaptor.getPosition().getModelOffset() == dest.getModelOffset()) {
+            int tweakOffset = findCharMotion.backwards ? -1 : 1;
             try {
                 //move cursor to be on top of the last match
                 editorAdaptor.setPosition(dest.addModelOffset(tweakOffset), StickyColumnPolicy.NEVER);
                 //try again
-                dest = findMotion.destination(editorAdaptor, count);
+                dest = findCharMotion.destination(editorAdaptor, count);
             }
             catch(CommandExecutionException e) {
                 //no match, un-tweak the cursor position

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
@@ -5,6 +5,10 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 
+/**
+ * Motion responsible for repeating <code>t</code>, <code>T</code>, <code>f</code> and
+ * <code>F</code> motions. Finds next occurrence of a character in current line.
+ */
 public class ContinueFindingMotion extends CountAwareMotion {
 
     public static final ContinueFindingMotion NORMAL = new ContinueFindingMotion(false);

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/ContinueFindingMotion.java
@@ -30,23 +30,6 @@ public class ContinueFindingMotion extends CountAwareMotion {
         }
         borderPolicy = findCharMotion.borderPolicy();
         Position dest = findCharMotion.destination(editorAdaptor, count);
-        //If using 't' and the cursor is before the last match, destination()
-        //will think this position is the next match and not move the cursor.
-        //If this happens, move the cursor forward one (so it's on top of the
-        //last match) and run destination() again.  If 'T', go back one.
-        if(!findCharMotion.upToTarget && editorAdaptor.getPosition().getModelOffset() == dest.getModelOffset()) {
-            int tweakOffset = findCharMotion.backwards ? -1 : 1;
-            try {
-                //move cursor to be on top of the last match
-                editorAdaptor.setPosition(dest.addModelOffset(tweakOffset), StickyColumnPolicy.NEVER);
-                //try again
-                dest = findCharMotion.destination(editorAdaptor, count);
-            }
-            catch(CommandExecutionException e) {
-                //no match, un-tweak the cursor position
-                editorAdaptor.setPosition(dest.addModelOffset(tweakOffset * -1), StickyColumnPolicy.NEVER);
-            }
-        }
         return dest;
     }
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/CountAwareMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/CountAwareMotion.java
@@ -4,7 +4,7 @@ import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 
-public abstract class CountAwareMotion implements Motion {
+public abstract class CountAwareMotion extends AbstractMotion {
 
     public abstract Position destination(EditorAdaptor editorAdaptor, int count) throws CommandExecutionException;
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/CountedMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/CountedMotion.java
@@ -39,4 +39,8 @@ public class CountedMotion implements Motion {
         return motion.isJump();
     }
 
+    @Override
+    public <T> T getAdapter(Class<T> type) {
+        return motion.getAdapter(type);
+    }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
@@ -14,18 +14,18 @@ import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
  * 
  * @author Krzysiek Goj
  */
-public class FindMotion extends FindBalancedMotion {
+public class FindCharMotion extends FindBalancedMotion {
 
     public static Function<Motion, KeyStroke> keyConverter(final boolean upToTarget, final boolean reversed) {
         return new Function<Motion, KeyStroke>() {
             public Motion call(KeyStroke keyStroke) {
-                return new FindMotion(keyStroke.getCharacter(), upToTarget, reversed).registrator;
+                return new FindCharMotion(keyStroke.getCharacter(), upToTarget, reversed).registrator;
             }
         };
 
     }
 
-    public FindMotion(char target, boolean upToTarget, boolean reversed) {
+    public FindCharMotion(char target, boolean upToTarget, boolean reversed) {
         super(target, '\0', upToTarget, reversed, true);
     }
 
@@ -36,24 +36,24 @@ public class FindMotion extends FindBalancedMotion {
         return end;
     }
 
-    public FindMotion reversed() {
-        return new FindMotion(target, upToTarget, !backwards);
+    public FindCharMotion reversed() {
+        return new FindCharMotion(target, upToTarget, !backwards);
     }
     
     private Motion registrator = new CountAwareMotion() {
         @Override
         public Position destination(EditorAdaptor editorAdaptor, int count)
                 throws CommandExecutionException {
-            editorAdaptor.getRegisterManager().setLastFindMotion(FindMotion.this);
-            return FindMotion.this.destination(editorAdaptor, count);
+            editorAdaptor.getRegisterManager().setLastFindCharMotion(FindCharMotion.this);
+            return FindCharMotion.this.destination(editorAdaptor, count);
         }
 
         public BorderPolicy borderPolicy() {
-            return FindMotion.this.borderPolicy();
+            return FindCharMotion.this.borderPolicy();
         }
 
         public StickyColumnPolicy stickyColumnPolicy() {
-            return FindMotion.this.stickyColumnPolicy();
+            return FindCharMotion.this.stickyColumnPolicy();
         }
     };
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
@@ -5,6 +5,7 @@ import net.sourceforge.vrapper.platform.TextContent;
 import net.sourceforge.vrapper.utils.Function;
 import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.Reversible;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
@@ -15,7 +16,7 @@ import net.sourceforge.vrapper.vim.commands.Repeatable;
  * 
  * @author Krzysiek Goj
  */
-public class FindCharMotion extends FindBalancedMotion implements Repeatable<FindCharMotion> {
+public class FindCharMotion extends FindBalancedMotion implements Repeatable<FindCharMotion>, Reversible<FindCharMotion> {
 
     public static Function<Motion, KeyStroke> keyConverter(final boolean upToTarget, final boolean reversed) {
         return new Function<Motion, KeyStroke>() {
@@ -37,6 +38,16 @@ public class FindCharMotion extends FindBalancedMotion implements Repeatable<Fin
         FindCharMotion repetition = new FindCharMotion(target, upToTarget, backwards);
         repetition.isRepetition = true;
         return repetition;
+    }
+
+    @Override
+    public FindCharMotion reverse() {
+        return new FindCharMotion(target, upToTarget, !backwards);
+    }
+
+    @Override
+    public boolean isBackward() {
+        return backwards;
     }
 
     @Override
@@ -72,10 +83,6 @@ public class FindCharMotion extends FindBalancedMotion implements Repeatable<Fin
         return dest;
     }
 
-    public FindCharMotion reversed() {
-        return new FindCharMotion(target, upToTarget, !backwards);
-    }
-    
     private Motion registrator = new CountAwareMotion() {
         @Override
         public Position destination(EditorAdaptor editorAdaptor, int count)

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
@@ -8,13 +8,14 @@ import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.Repeatable;
 
 /** Motion responsible for 't', 'T', 'f' and 'F' motions.
  * Finds next occurrence of a character in current line.
  * 
  * @author Krzysiek Goj
  */
-public class FindCharMotion extends FindBalancedMotion {
+public class FindCharMotion extends FindBalancedMotion implements Repeatable<FindCharMotion> {
 
     public static Function<Motion, KeyStroke> keyConverter(final boolean upToTarget, final boolean reversed) {
         return new Function<Motion, KeyStroke>() {
@@ -25,8 +26,17 @@ public class FindCharMotion extends FindBalancedMotion {
 
     }
 
+    protected boolean isRepetition;
+
     public FindCharMotion(char target, boolean upToTarget, boolean reversed) {
         super(target, '\0', upToTarget, reversed, true);
+    }
+
+    @Override
+    public FindCharMotion repetition() {
+        FindCharMotion repetition = new FindCharMotion(target, upToTarget, backwards);
+        repetition.isRepetition = true;
+        return repetition;
     }
 
     @Override
@@ -34,6 +44,32 @@ public class FindCharMotion extends FindBalancedMotion {
         LineInformation line = content.getLineInformationOfOffset(offset);
         int end = backwards ? line.getBeginOffset() : line.getEndOffset() - 1;
         return end;
+    }
+
+    @Override
+    public Position destination(EditorAdaptor editorAdaptor, int count)
+            throws CommandExecutionException {
+
+        Position dest = super.destination(editorAdaptor, count);
+
+        // If repeating 't' / 'T' and the cursor is before the last match, destination() will think
+        // this position is the next match and not move the cursor. If this happens, move the cursor
+        // forward or back so it's on top of the last match and run destination() again.
+        if (isRepetition && ! upToTarget
+                && editorAdaptor.getPosition().getModelOffset() == dest.getModelOffset()) {
+
+            Position originalPos = dest;
+            Position tweakPos = dest.addModelOffset(backwards ? -1 : 1);
+            try {
+                editorAdaptor.setPosition(tweakPos, StickyColumnPolicy.NEVER);
+                dest = super.destination(editorAdaptor, count);
+            }
+            catch(CommandExecutionException e) {
+                //no match, un-tweak the cursor position
+                editorAdaptor.setPosition(originalPos, StickyColumnPolicy.NEVER);
+            }
+        }
+        return dest;
     }
 
     public FindCharMotion reversed() {
@@ -44,7 +80,7 @@ public class FindCharMotion extends FindBalancedMotion {
         @Override
         public Position destination(EditorAdaptor editorAdaptor, int count)
                 throws CommandExecutionException {
-            editorAdaptor.getRegisterManager().setLastFindCharMotion(FindCharMotion.this);
+            editorAdaptor.getRegisterManager().setLastFindCharMotion(FindCharMotion.this.repetition());
             return FindCharMotion.this.destination(editorAdaptor, count);
         }
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/FindCharMotion.java
@@ -5,18 +5,16 @@ import net.sourceforge.vrapper.platform.TextContent;
 import net.sourceforge.vrapper.utils.Function;
 import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
-import net.sourceforge.vrapper.utils.Reversible;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
-import net.sourceforge.vrapper.vim.commands.Repeatable;
 
 /** Motion responsible for 't', 'T', 'f' and 'F' motions.
  * Finds next occurrence of a character in current line.
  * 
  * @author Krzysiek Goj
  */
-public class FindCharMotion extends FindBalancedMotion implements Repeatable<FindCharMotion>, Reversible<FindCharMotion> {
+public class FindCharMotion extends FindBalancedMotion implements NavigatingMotion {
 
     public static Function<Motion, KeyStroke> keyConverter(final boolean upToTarget, final boolean reversed) {
         return new Function<Motion, KeyStroke>() {
@@ -83,6 +81,17 @@ public class FindCharMotion extends FindBalancedMotion implements Repeatable<Fin
         return dest;
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getAdapter(Class<T> type) {
+        if (NavigatingMotion.class.equals(type)) {
+            return (T) this;
+        } else if (FindCharMotion.class.equals(type)) {
+            return (T) this;
+        }
+        return super.getAdapter(type);
+    }
+
     private Motion registrator = new CountAwareMotion() {
         @Override
         public Position destination(EditorAdaptor editorAdaptor, int count)
@@ -97,6 +106,11 @@ public class FindCharMotion extends FindBalancedMotion implements Repeatable<Fin
 
         public StickyColumnPolicy stickyColumnPolicy() {
             return FindCharMotion.this.stickyColumnPolicy();
+        }
+
+        @Override
+        public <T> T getAdapter(Class<T> type) {
+            return FindCharMotion.this.getAdapter(type);
         }
     };
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/GoToMarkMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/GoToMarkMotion.java
@@ -11,7 +11,7 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 
-public class GoToMarkMotion implements Motion {
+public class GoToMarkMotion extends AbstractMotion {
 
     public static final Function<Motion, KeyStroke> LINEWISE_CONVERTER = new Function<Motion, KeyStroke>() {
         public Motion call(KeyStroke arg) {
@@ -68,5 +68,4 @@ public class GoToMarkMotion implements Motion {
     public boolean isJump() {
         return true;
     }
-
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/Motion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/Motion.java
@@ -2,11 +2,12 @@ package net.sourceforge.vrapper.vim.commands.motions;
 
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.Adaptable;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.commands.Counted;
 
-public interface Motion extends Counted<Motion> {
+public interface Motion extends Counted<Motion>, Adaptable {
     Position destination(EditorAdaptor editorAdaptor) throws CommandExecutionException;
     BorderPolicy borderPolicy();
     StickyColumnPolicy stickyColumnPolicy();

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/NavigatingMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/NavigatingMotion.java
@@ -1,0 +1,12 @@
+package net.sourceforge.vrapper.vim.commands.motions;
+
+import net.sourceforge.vrapper.utils.Reversible;
+import net.sourceforge.vrapper.vim.commands.Repeatable;
+
+/**
+ * Composite interface for those motions which are reversible. Instances of this class can be
+ * assigned to the register manager for use with the keybinds like <code>;</code> and <code>,</code>
+ * (done through plugs in any of the plugins).
+ */
+public interface NavigatingMotion extends Motion, Reversible<NavigatingMotion>, Repeatable<NavigatingMotion> {
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/PercentMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/PercentMotion.java
@@ -5,7 +5,7 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 
-public class PercentMotion implements Motion {
+public class PercentMotion extends AbstractMotion {
 
     public static final Motion INSTANCE = new PercentMotion();
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/PercentOfFileMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/PercentOfFileMotion.java
@@ -12,7 +12,7 @@ import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
  * Motion to go to the line closest to <i>count</i> percent of the file.
  * Also see <code>N%</code> in the Vim help document.
  */
-public class PercentOfFileMotion implements Motion {
+public class PercentOfFileMotion extends AbstractMotion {
 
     protected int count;
 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/RangeSearchMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/RangeSearchMotion.java
@@ -13,7 +13,7 @@ import net.sourceforge.vrapper.vim.modes.commandline.SearchCommandParser;
  * Find a string the user entered as a start or end to a range.
  * (no need to bring up SearchMode or track this as the last search)
  */
-public class RangeSearchMotion implements Motion {
+public class RangeSearchMotion extends AbstractMotion {
 	
 	private String toFind;
 	private Position start;

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/SearchResultMotion.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/motions/SearchResultMotion.java
@@ -26,6 +26,10 @@ import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.commands.TextObject;
 import net.sourceforge.vrapper.vim.modes.commandline.HighlightSearch;
 
+/**
+ * This motion is used to back search mode. Not to be confused with {@link ContinueFindingMotion},
+ * which is used for in-line searches like <code>f</code>/<code>t</code>.
+ */
 public class SearchResultMotion extends CountAwareMotion {
 
     public static final SearchResultMotion REPEAT = new SearchResultMotion(false);

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/CommandBasedMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/CommandBasedMode.java
@@ -27,7 +27,7 @@ import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.commands.SwitchRegisterCommand;
 import net.sourceforge.vrapper.vim.commands.VimCommandSequence;
 import net.sourceforge.vrapper.vim.commands.motions.ContinueFindingMotion;
-import net.sourceforge.vrapper.vim.commands.motions.FindMotion;
+import net.sourceforge.vrapper.vim.commands.motions.FindCharMotion;
 import net.sourceforge.vrapper.vim.commands.motions.GoToEditLocation;
 import net.sourceforge.vrapper.vim.commands.motions.GoToLineMotion;
 import net.sourceforge.vrapper.vim.commands.motions.GoToMarkMotion;
@@ -187,16 +187,16 @@ public abstract class CommandBasedMode extends AbstractMode {
                     leafBind(SpecialKey.PAGE_UP, PageScrollMotion.SCROLL_PGUP),
                     leafBind(';', findForward),
                     leafBind(',', findBackward),
-                    transitionBind('t', convertKeyStroke(FindMotion
+                    transitionBind('t', convertKeyStroke(FindCharMotion
                             .keyConverter(false, false),
                             VimConstants.PRINTABLE_KEYSTROKES)),
-                    transitionBind('T', convertKeyStroke(FindMotion
+                    transitionBind('T', convertKeyStroke(FindCharMotion
                             .keyConverter(false, true),
                             VimConstants.PRINTABLE_KEYSTROKES)),
-                    transitionBind('f', convertKeyStroke(FindMotion
+                    transitionBind('f', convertKeyStroke(FindCharMotion
                             .keyConverter(true, false),
                             VimConstants.PRINTABLE_KEYSTROKES)),
-                    transitionBind('F', convertKeyStroke(FindMotion
+                    transitionBind('F', convertKeyStroke(FindCharMotion
                             .keyConverter(true, true),
                             VimConstants.PRINTABLE_KEYSTROKES)),
                     transitionBind('\'', convertKeyStroke(

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/CommandBasedMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/CommandBasedMode.java
@@ -87,6 +87,8 @@ public abstract class CommandBasedMode extends AbstractMode {
     public void enterMode(ModeSwitchHint... hints) throws CommandExecutionException {
         super.enterMode(hints);
         commandBufferRemapIndex = -1;
+        // Clean up state from previous time in case we left through a non-leaf state
+        reset();
     }
 
     /** Reset cursor position if it is at the end of the line and the current mode won't allow it. 

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/NormalMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/NormalMode.java
@@ -26,6 +26,7 @@ import net.sourceforge.vrapper.platform.CursorService;
 import net.sourceforge.vrapper.utils.CaretType;
 import net.sourceforge.vrapper.utils.LineInformation;
 import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.VimUtils;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.VimConstants;
 import net.sourceforge.vrapper.vim.commands.AsciiCommand;
@@ -317,13 +318,13 @@ public class NormalMode extends CommandBasedMode {
     public void enterMode(final ModeSwitchHint... args) throws CommandExecutionException {
         editorAdaptor.getCursorService().setCaret(CaretType.RECTANGULAR);
         super.enterMode(args);
-        if (args.length > 0) {
-            if(args[0] instanceof ExecuteCommandHint) {
-                try {
-                    executeCommand(((ExecuteCommandHint.OnEnter) args[0]).getCommand());
-                } catch (final CommandExecutionException e) {
-                    editorAdaptor.getUserInterfaceService().setErrorMessage(e.getMessage());
-                }
+        // Check OnEnter hint
+        ExecuteCommandHint hint = VimUtils.findModeHint(ExecuteCommandHint.OnEnter.class, args);
+        if (hint != null) {
+            try {
+                executeCommand(hint.getCommand());
+            } catch (final CommandExecutionException e) {
+                editorAdaptor.getUserInterfaceService().setErrorMessage(e.getMessage());
             }
         }
         placeCursor(StickyColumnPolicy.NEVER);

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/SearchCommandParser.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/SearchCommandParser.java
@@ -11,13 +11,13 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.Options;
 import net.sourceforge.vrapper.vim.VimConstants;
 import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.motions.SearchResultMotion;
 import net.sourceforge.vrapper.vim.modes.AbstractVisualMode;
 import net.sourceforge.vrapper.vim.modes.ExecuteCommandHint;
 
 /**
- * Mode for input of search parameters (keyword and offset).
- *
- * @author Matthias Radig
+ * Parser for input of search parameters (keyword and offset). This class is used together with
+ * {@link SearchResultMotion} to implement the search functionality.
  */
 public class SearchCommandParser extends AbstractCommandParser {
 
@@ -28,7 +28,7 @@ public class SearchCommandParser extends AbstractCommandParser {
         super(vim);
         this.commandToExecute = commandToExecute;
     }
-    
+
     /**
      * Parses and executes a search.
      *
@@ -40,6 +40,7 @@ public class SearchCommandParser extends AbstractCommandParser {
         editor.getRegisterManager().setSearch(search);
         editor.setLastSearchResult(null);
         editor.getSearchAndReplaceService().removeHighlighting();
+        // This is typically an instance of MotionCommand containing a SearchResultMotion instance.
         return commandToExecute;
     }
 
@@ -68,7 +69,7 @@ public class SearchCommandParser extends AbstractCommandParser {
             || (editor.getConfiguration().get(Options.SMART_CASE)
                 && StringUtils.containsUppercase(keyword));
         boolean searchInSelection = false;
-        
+
         //special case to override global 'ignorecase' property (see :help \c)
         if(keyword.contains("\\c")) {
         	int index = keyword.indexOf("\\c");

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/SearchMode.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/commandline/SearchMode.java
@@ -23,6 +23,10 @@ import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
 import net.sourceforge.vrapper.vim.modes.ExecuteCommandHint;
 import net.sourceforge.vrapper.vim.modes.ModeSwitchHint;
 
+/**
+ * Mode for input of search parameters (keyword and offset). This class is used together with
+ * {@link SearchResultMotion} to implement the search functionality.
+ */
 public class SearchMode extends AbstractCommandLineMode {
 
     protected class SearchConfigurationListener implements

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
@@ -12,7 +12,7 @@ import net.sourceforge.vrapper.utils.StringUtils;
 import net.sourceforge.vrapper.utils.VimUtils;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.SubstitutionOperation;
-import net.sourceforge.vrapper.vim.commands.motions.FindMotion;
+import net.sourceforge.vrapper.vim.commands.motions.FindCharMotion;
 
 
 /**
@@ -31,7 +31,7 @@ public class DefaultRegisterManager implements RegisterManager {
     private Search search;
     private Command lastEdit, lastInsertion;
     private SubstitutionOperation lastSubstitution;
-    private FindMotion findMotion;
+    private FindCharMotion findCharMotion;
 	private SelectionArea lastActiveSelectionArea;
 	private String cwd = "/";
 	private String lastCommand;
@@ -151,12 +151,12 @@ public class DefaultRegisterManager implements RegisterManager {
         this.lastEdit = lastEdit;
     }
 
-    public FindMotion getLastFindMotion() {
-        return findMotion;
+    public FindCharMotion getLastFindCharMotion() {
+        return findCharMotion;
     }
 
-    public void setLastFindMotion(FindMotion motion) {
-        findMotion = motion;
+    public void setLastFindCharMotion(FindCharMotion motion) {
+        findCharMotion = motion;
     }
 
     public void setActiveRegister(Register register) {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/DefaultRegisterManager.java
@@ -13,6 +13,7 @@ import net.sourceforge.vrapper.utils.VimUtils;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.SubstitutionOperation;
 import net.sourceforge.vrapper.vim.commands.motions.FindCharMotion;
+import net.sourceforge.vrapper.vim.commands.motions.NavigatingMotion;
 
 
 /**
@@ -32,6 +33,7 @@ public class DefaultRegisterManager implements RegisterManager {
     private Command lastEdit, lastInsertion;
     private SubstitutionOperation lastSubstitution;
     private FindCharMotion findCharMotion;
+    private NavigatingMotion lastNavigatingMotion;
 	private SelectionArea lastActiveSelectionArea;
 	private String cwd = "/";
 	private String lastCommand;
@@ -157,6 +159,14 @@ public class DefaultRegisterManager implements RegisterManager {
 
     public void setLastFindCharMotion(FindCharMotion motion) {
         findCharMotion = motion;
+    }
+
+    public void setLastNavigatingMotion(NavigatingMotion motion) {
+        lastNavigatingMotion = motion;
+    }
+
+    public NavigatingMotion getLastNavigatingMotion() {
+        return lastNavigatingMotion;
     }
 
     public void setActiveRegister(Register register) {

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
@@ -7,6 +7,7 @@ import net.sourceforge.vrapper.utils.SelectionArea;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.SubstitutionOperation;
 import net.sourceforge.vrapper.vim.commands.motions.FindCharMotion;
+import net.sourceforge.vrapper.vim.commands.motions.NavigatingMotion;
 
 /**
  * Provides access to different registers.
@@ -51,6 +52,10 @@ public interface RegisterManager {
     void setLastDelete(RegisterContent register);
     void setLastFindCharMotion(FindCharMotion motion);
     FindCharMotion getLastFindCharMotion();
+    /** Used to differentiate between f/t used in dfx vs plain fx. */
+    void setLastNavigatingMotion(NavigatingMotion motion);
+    /** Used to differentiate between f/t used in dfx vs plain fx. */
+    NavigatingMotion getLastNavigatingMotion();
     Search getSearch();
     void setSearch(Search search);
     boolean isDefaultRegisterActive();

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/register/RegisterManager.java
@@ -6,7 +6,7 @@ import net.sourceforge.vrapper.utils.Search;
 import net.sourceforge.vrapper.utils.SelectionArea;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.SubstitutionOperation;
-import net.sourceforge.vrapper.vim.commands.motions.FindMotion;
+import net.sourceforge.vrapper.vim.commands.motions.FindCharMotion;
 
 /**
  * Provides access to different registers.
@@ -49,8 +49,8 @@ public interface RegisterManager {
     SubstitutionOperation getLastSubstitution();
     void setLastYank(RegisterContent register);
     void setLastDelete(RegisterContent register);
-    void setLastFindMotion(FindMotion motion);
-    FindMotion getLastFindMotion();
+    void setLastFindCharMotion(FindCharMotion motion);
+    FindCharMotion getLastFindCharMotion();
     Search getSearch();
     void setSearch(Search search);
     boolean isDefaultRegisterActive();

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -5,6 +5,7 @@
    <extension-point id="net.sourceforge.vrapper.eclipse.extractor" name="Text Editor Extractor" schema="schema/net.sourceforge.vrapper.eclipse.extractor.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.psmp" name="Platform Specific Mode Provider" schema="schema/net.sourceforge.vrapper.eclipse.psmp.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.pstop" name="Platform Specific TextObject provider" schema="schema/net.sourceforge.vrapper.eclipse.pstop.exsd"/>
+   <extension-point id="net.sourceforge.vrapper.eclipse.lifecyclelistener" name="Vrapper Lifecycle Listener" schema="schema/net.sourceforge.vrapper.eclipse.lifecyclelistener.exsd"/>
   <extension
        point="org.eclipse.ui.commands">
     <category

--- a/net.sourceforge.vrapper.eclipse/schema/net.sourceforge.vrapper.eclipse.lifecyclelistener.exsd
+++ b/net.sourceforge.vrapper.eclipse/schema/net.sourceforge.vrapper.eclipse.lifecyclelistener.exsd
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="net.sourceforge.vrapper.eclipse" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="net.sourceforge.vrapper.eclipse" id="net.sourceforge.vrapper.eclipse.lifecyclelistener" name="Vrapper Lifecycle Listener"/>
+      </appInfo>
+      <documentation>
+         Extension that defines listeners to be triggered when Vrapper hooks into a new editor or unhooks from a closing editor.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="lifecycle-listener"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="lifecycle-listener">
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="identifier"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="listener-class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn="net.sourceforge.vrapper.platform.PlatformVrapperLifecycleAdapter:"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         0.67.0
+      </documentation>
+   </annotation>
+
+
+
+
+
+</schema>

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptorFactory.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptorFactory.java
@@ -1,7 +1,10 @@
 package net.sourceforge.vrapper.eclipse.interceptor;
 
 import net.sourceforge.vrapper.platform.BufferAndTabService;
+import net.sourceforge.vrapper.platform.PlatformVrapperLifecycleListener;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+import java.util.List;
 
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
@@ -14,6 +17,7 @@ import org.eclipse.ui.texteditor.AbstractTextEditor;
 public interface InputInterceptorFactory {
 
     InputInterceptor createInterceptor(AbstractTextEditor part, ISourceViewer textViewer,
-            EditorInfo partInfo, BufferAndTabService bufferAndTabService);
+            EditorInfo partInfo, BufferAndTabService bufferAndTabService,
+            List<PlatformVrapperLifecycleListener> lifecycleListeners);
     InputInterceptor createInterceptor(EditorAdaptor editorAdaptor);
 }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
@@ -18,6 +18,7 @@ import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.platform.BufferAndTabService;
 import net.sourceforge.vrapper.platform.Configuration.Option;
 import net.sourceforge.vrapper.platform.GlobalConfiguration;
+import net.sourceforge.vrapper.platform.PlatformVrapperLifecycleListener;
 import net.sourceforge.vrapper.vim.ConfigurationListener;
 import net.sourceforge.vrapper.vim.DefaultConfigProvider;
 import net.sourceforge.vrapper.vim.DefaultEditorAdaptor;
@@ -202,13 +203,13 @@ public class VimInputInterceptorFactory implements InputInterceptorFactory {
 
     @Override
     public InputInterceptor createInterceptor(AbstractTextEditor abstractTextEditor,
-            ISourceViewer textViewer, EditorInfo partInfo, BufferAndTabService bufferAndTabService) {
+            ISourceViewer textViewer, EditorInfo partInfo, BufferAndTabService bufferAndTabService,
+            List<PlatformVrapperLifecycleListener> lifecycleListeners) {
 
         EclipsePlatform platform = new EclipsePlatform(partInfo, abstractTextEditor, textViewer,
                 sharedConfiguration, bufferAndTabService);
-        DefaultEditorAdaptor editorAdaptor = new DefaultEditorAdaptor(
-                platform,
-                globalRegisterManager, VrapperPlugin.isVrapperEnabled());
+        DefaultEditorAdaptor editorAdaptor = new DefaultEditorAdaptor(platform,
+                globalRegisterManager, VrapperPlugin.isVrapperEnabled(), lifecycleListeners);
         editorAdaptor.addVrapperEventListener(platform.getModeRecorder());
         InputInterceptor interceptor = createInterceptor(editorAdaptor);
         interceptor.setPlatform(platform);

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/AbstractEclipseSpecificStateProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/keymap/AbstractEclipseSpecificStateProvider.java
@@ -12,6 +12,7 @@ import net.sourceforge.vrapper.platform.PlatformSpecificStateProvider;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.TextObjectProvider;
 import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.modes.AbstractVisualMode;
 import net.sourceforge.vrapper.vim.modes.ContentAssistMode;
 import net.sourceforge.vrapper.vim.modes.InsertMode;
@@ -113,7 +114,7 @@ public class AbstractEclipseSpecificStateProvider implements
             this.async = async;
         }
 
-        public Object evaluate(EditorAdaptor vim, Queue<String> command) {
+        public Object evaluate(EditorAdaptor vim, Queue<String> command) throws CommandExecutionException {
             String name = command.poll();
             if("!".equals(name)) {
             	//we made a change where the '!' is separated from the command name
@@ -123,8 +124,7 @@ public class AbstractEclipseSpecificStateProvider implements
             }
             String action = command.poll();
             if (name != null && action != null) {
-                CommandLineMode mode = (CommandLineMode) vim
-                        .getMode(CommandLineMode.NAME);
+                CommandLineMode mode = (CommandLineMode) vim.getMode(CommandLineMode.NAME);
                 mode.addCommand(name, new EclipseCommand(action, async), force);
             }
             return null;

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseHighlightingService.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseHighlightingService.java
@@ -1,7 +1,7 @@
 package net.sourceforge.vrapper.eclipse.platform;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -34,7 +34,7 @@ public class EclipseHighlightingService implements HighlightingService {
         final IAnnotationModel am = getAnnotationModel();
         if (am instanceof IAnnotationModelExtension) {
             IAnnotationModelExtension ame = (IAnnotationModelExtension) am;
-            Map temp = new HashMap(regions.size());
+            Map temp = new LinkedHashMap(regions.size());
             for (TextRange region : regions) {
                 Annotation annotation = new Annotation(type, false, name);
                 int offset = region.getLeftBound().getModelOffset();

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
@@ -213,6 +213,9 @@ public class EclipsePlatform implements Platform {
                 .getConfigurationElementsFor("net.sourceforge.vrapper.eclipse.pssp");
         final List<AbstractEclipseSpecificStateProvider> matched = new ArrayList<AbstractEclipseSpecificStateProvider>();
         for (final IConfigurationElement element : elements) {
+            if (VrapperLog.isDebugEnabled()) {
+                VrapperLog.debug("Loading Vrapper state provider " + element.getAttribute("name"));
+            }
             try {
                 final AbstractEclipseSpecificStateProvider provider = (AbstractEclipseSpecificStateProvider) Utils
                         .createGizmoForElementConditionally(
@@ -222,6 +225,10 @@ public class EclipsePlatform implements Platform {
                     provider.configure(element);
                     provider.initializeProvider(textObjectProvider);
                     matched.add(provider);
+                    if (VrapperLog.isDebugEnabled()) {
+                        VrapperLog.debug("Vrapper state provider " + element.getAttribute("name")
+                                + " configured");
+                    }
                 }
             } catch (Exception e) {
                 VrapperLog.error("Failed to initialize state provider " + element, e);

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak.feature/.project
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>net.sourceforge.vrapper.plugin.sneak.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak.feature/build.properties
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak.feature/feature.xml
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak.feature/feature.xml
@@ -1,0 +1,876 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="net.sourceforge.vrapper.plugin.sneak"
+      label="Vrapper - Sneak Plugin (Optional)"
+      version="0.71.20160927"
+      provider-name="Vrapper Team">
+
+   <description url="http://vrapper.sourceforge.net/documentation/">
+      Vrapper port of Justin Keyes&apos; vim-sneak plugin.
+For info on vim-sneak, see: https://github.com/justinmk/vim-sneak
+or http://www.vim.org/scripts/script.php?script_id=4809
+   </description>
+
+   <copyright>
+      Copyright 2009 Krzysztof Goj
+   </copyright>
+
+   <license url="http://www.gnu.org/licenses/gpl-3.0.txt">
+      GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+Copyright (C) 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+Preamble
+The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+The licenses for most software and other practical works are
+designed
+to take away your freedom to share and change the works.  By
+contrast,
+the GNU General Public License is intended to guarantee your
+freedom to
+share and change all versions of a program--to make sure it remains
+free
+software for all its users.  We, the Free Software Foundation,
+use the
+GNU General Public License for most of our software; it applies
+also to
+any other work released this way by its authors.  You can apply
+it to
+your programs, too.
+When we speak of free software, we are referring to freedom,
+not
+price.  Our General Public Licenses are designed to make sure
+that you
+have the freedom to distribute copies of free software (and charge
+for
+them if you wish), that you receive source code or can get it
+if you
+want it, that you can change the software or use pieces of it
+in new
+free programs, and that you know you can do these things.
+To protect your rights, we need to prevent others from denying
+you
+these rights or asking you to surrender the rights.  Therefore,
+you have
+certain responsibilities if you distribute copies of the software,
+or if
+you modify it: responsibilities to respect the freedom of others.
+For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too,
+receive
+or can get the source code.  And you must show them these terms
+so they
+know their rights.
+Developers that use the GNU GPL protect your rights with two
+steps:
+(1) assert copyright on the software, and (2) offer you this
+License
+giving you legal permission to copy, distribute and/or modify
+it.
+For the developers&apos; and authors&apos; protection, the GPL clearly
+explains
+that there is no warranty for this free software.  For both users&apos;
+and
+authors&apos; sake, the GPL requires that modified versions be marked
+as
+changed, so that their problems will not be attributed erroneously
+to
+authors of previous versions.
+Some devices are designed to deny users access to install or
+run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users&apos; freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals
+to
+use, which is precisely where it is most unacceptable.  Therefore,
+we
+have designed this version of the GPL to prohibit the practice
+for those
+products.  If such problems arise substantially in other domains,
+we
+stand ready to extend this provision to those domains in future
+versions
+of the GPL, as needed to protect the freedom of users.
+Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use
+of
+software on general-purpose computers, but in those that do,
+we wish to
+avoid the special danger that patents applied to a free program
+could
+make it effectively proprietary.  To prevent this, the GPL assures
+that
+patents cannot be used to render the program non-free.
+The precise terms and conditions for copying, distribution and
+modification follow.
+TERMS AND CONDITIONS
+0. Definitions.
+&quot;This License&quot; refers to version 3 of the GNU General Public
+License.
+&quot;Copyright&quot; also means copyright-like laws that apply to other
+kinds of
+works, such as semiconductor masks.
+&quot;The Program&quot; refers to any copyrightable work licensed under
+this
+License.  Each licensee is addressed as &quot;you&quot;.  &quot;Licensees&quot; and
+&quot;recipients&quot; may be individuals or organizations.
+To &quot;modify&quot; a work means to copy from or adapt all or part of
+the work
+in a fashion requiring copyright permission, other than the making
+of an
+exact copy.  The resulting work is called a &quot;modified version&quot;
+of the
+earlier work or a work &quot;based on&quot; the earlier work.
+A &quot;covered work&quot; means either the unmodified Program or a work
+based
+on the Program.
+To &quot;propagate&quot; a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing
+it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available
+to the
+public, and in some countries other activities as well.
+To &quot;convey&quot; a work means any kind of propagation that enables
+other
+parties to make or receive copies.  Mere interaction with a user
+through
+a computer network, with no transfer of a copy, is not conveying.
+An interactive user interface displays &quot;Appropriate Legal Notices&quot;
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and
+(2)
+tells the user that there is no warranty for the work (except
+to the
+extent that warranties are provided), that licensees may convey
+the
+work under this License, and how to view a copy of this License.
+If
+the interface presents a list of user commands or options, such
+as a
+menu, a prominent item in the list meets this criterion.
+1. Source Code.
+The &quot;source code&quot; for a work means the preferred form of the
+work
+for making modifications to it.  &quot;Object code&quot; means any non-source
+form of a work.
+A &quot;Standard Interface&quot; means an interface that either is an official
+standard defined by a recognized standards body, or, in the case
+of
+interfaces specified for a particular programming language, one
+that
+is widely used among developers working in that language.
+The &quot;System Libraries&quot; of an executable work include anything,
+other
+than the work as a whole, that (a) is included in the normal
+form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with
+that
+Major Component, or to implement a Standard Interface for which
+an
+implementation is available to the public in source code form.
+A
+&quot;Major Component&quot;, in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating
+system
+(if any) on which the executable work runs, or a compiler used
+to
+produce the work, or an object code interpreter used to run it.
+The &quot;Corresponding Source&quot; for a work in object code form means
+all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts
+to
+control those activities.  However, it does not include the work&apos;s
+System Libraries, or general-purpose tools or generally available
+free
+programs which are used unmodified in performing those activities
+but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files
+for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to
+require,
+such as by intimate data communication or control flow between
+those
+subprograms and other parts of the work.
+The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+The Corresponding Source for a work in source code form is that
+same work.
+2. Basic Permissions.
+All rights granted under this License are granted for the term
+of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running
+a
+covered work is covered by this License only if the output, given
+its
+content, constitutes a covered work.  This License acknowledges
+your
+rights of fair use or other equivalent, as provided by copyright
+law.
+You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise
+remains
+in force.  You may convey covered works to others for the sole
+purpose
+of having them make modifications exclusively for you, or provide
+you
+with facilities for running those works, provided that you comply
+with
+the terms of this License in conveying all material for which
+you do
+not control copyright.  Those thus making or running the covered
+works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies
+of
+your copyrighted material outside their relationship with you.
+Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section
+10
+makes it unnecessary.
+3. Protecting Users&apos; Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under
+article
+11 of the WIPO copyright treaty adopted on 20 December 1996,
+or
+similar laws prohibiting or restricting circumvention of such
+measures.
+When you convey a covered work, you waive any legal power to
+forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect
+to
+the covered work, and you disclaim any intention to limit operation
+or
+modification of the work as a means of enforcing, against the
+work&apos;s
+users, your or third parties&apos; legal rights to forbid circumvention
+of
+technological measures.
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program&apos;s source code as
+you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to
+the code;
+keep intact all notices of the absence of any warranty; and give
+all
+recipients a copy of this License along with the Program.
+You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications
+to
+produce it from the Program, in the form of source code under
+the
+terms of section 4, provided that you also meet all of these
+conditions:
+a) The work must carry prominent notices stating that you modified
+it, and giving a relevant date.
+b) The work must carry prominent notices stating that it is
+released under this License and any conditions added under section
+7.  This requirement modifies the requirement in section 4 to
+&quot;keep intact all notices&quot;.
+c) You must license the entire work, as a whole, under this
+License to anyone who comes into possession of a copy.  This
+License will therefore apply, along with any applicable section
+7
+additional terms, to the whole of the work, and all its parts,
+regardless of how they are packaged.  This License gives no
+permission to license the work in any other way, but it does
+not
+invalidate such permission if you have separately received it.
+d) If the work has interactive user interfaces, each must display
+Appropriate Legal Notices; however, if the Program has interactive
+interfaces that do not display Appropriate Legal Notices, your
+work need not make them do so.
+A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered
+work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called
+an
+&quot;aggregate&quot; if the compilation and its resulting copyright are
+not
+used to limit the access or legal rights of the compilation&apos;s
+users
+beyond what the individual works permit.  Inclusion of a covered
+work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this
+License,
+in one of these ways:
+a) Convey the object code in, or embodied in, a physical product
+(including a physical distribution medium), accompanied by the
+Corresponding Source fixed on a durable physical medium
+customarily used for software interchange.
+b) Convey the object code in, or embodied in, a physical product
+(including a physical distribution medium), accompanied by a
+written offer, valid for at least three years and valid for as
+long as you offer spare parts or customer support for that product
+model, to give anyone who possesses the object code either (1)
+a
+copy of the Corresponding Source for all the software in the
+product that is covered by this License, on a durable physical
+medium customarily used for software interchange, for a price
+no
+more than your reasonable cost of physically performing this
+conveying of source, or (2) access to copy the
+Corresponding Source from a network server at no charge.
+c) Convey individual copies of the object code with a copy of
+the
+written offer to provide the Corresponding Source.  This
+alternative is allowed only occasionally and noncommercially,
+and
+only if you received the object code with such an offer, in accord
+with subsection 6b.
+d) Convey the object code by offering access from a designated
+place (gratis or for a charge), and offer equivalent access to
+the
+Corresponding Source in the same way through the same place at
+no
+further charge.  You need not require recipients to copy the
+Corresponding Source along with the object code.  If the place
+to
+copy the object code is a network server, the Corresponding Source
+may be on a different server (operated by you or a third party)
+that supports equivalent copying facilities, provided you maintain
+clear directions next to the object code saying where to find
+the
+Corresponding Source.  Regardless of what server hosts the
+Corresponding Source, you remain obligated to ensure that it
+is
+available for as long as needed to satisfy these requirements.
+e) Convey the object code using peer-to-peer transmission, provided
+you inform other peers where the object code and Corresponding
+Source of the work are being offered to the general public at
+no
+charge under subsection 6d.
+A separable portion of the object code, whose source code is
+excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+A &quot;User Product&quot; is either (1) a &quot;consumer product&quot;, which means
+any
+tangible personal property which is normally used for personal,
+family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer
+product,
+doubtful cases shall be resolved in favor of coverage.  For a
+particular
+product received by a particular user, &quot;normally used&quot; refers
+to a
+typical or common use of that class of product, regardless of
+the status
+of the particular user or of the way in which the particular
+user
+actually uses, or expects or is expected to use, the product.
+A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses
+represent
+the only significant mode of use of the product.
+&quot;Installation Information&quot; for a User Product means any methods,
+procedures, authorization keys, or other information required
+to install
+and execute modified versions of a covered work in that User
+Product from
+a modified version of its Corresponding Source.  The information
+must
+suffice to ensure that the continued functioning of the modified
+object
+code is in no case prevented or interfered with solely because
+modification has been made.
+If you convey an object code work under this section in, or with,
+or
+specifically for use in, a User Product, and the conveying occurs
+as
+part of a transaction in which the right of possession and use
+of the
+User Product is transferred to the recipient in perpetuity or
+for a
+fixed term (regardless of how the transaction is characterized),
+the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not
+apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work
+has
+been installed in ROM).
+The requirement to provide Installation Information does not
+include a
+requirement to continue to provide support service, warranty,
+or updates
+for a work that has been modified or installed by the recipient,
+or for
+the User Product in which it has been modified or installed.
+Access to a
+network may be denied when the modification itself materially
+and
+adversely affects the operation of the network or violates the
+rules and
+protocols for communication across the network.
+Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public
+in
+source code form), and must require no special password or key
+for
+unpacking, reading or copying.
+7. Additional Terms.
+&quot;Additional permissions&quot; are terms that supplement the terms
+of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program
+shall
+be treated as though they were included in this License, to the
+extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed
+by
+this License without regard to the additional permissions.
+When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any
+part of
+it.  (Additional permissions may be written to require their
+own
+removal in certain cases when you modify the work.)  You may
+place
+additional permissions on material, added by you to a covered
+work,
+for which you have or can give appropriate copyright permission.
+Notwithstanding any other provision of this License, for material
+you
+add to a covered work, you may (if authorized by the copyright
+holders of
+that material) supplement the terms of this License with terms:
+a) Disclaiming warranty or limiting liability differently from
+the
+terms of sections 15 and 16 of this License; or
+b) Requiring preservation of specified reasonable legal notices
+or
+author attributions in that material or in the Appropriate Legal
+Notices displayed by works containing it; or
+c) Prohibiting misrepresentation of the origin of that material,
+or
+requiring that modified versions of such material be marked in
+reasonable ways as different from the original version; or
+d) Limiting the use for publicity purposes of names of licensors
+or
+authors of the material; or
+e) Declining to grant rights under trademark law for use of some
+trade names, trademarks, or service marks; or
+f) Requiring indemnification of licensors and authors of that
+material by anyone who conveys the material (or modified versions
+of
+it) with contractual assumptions of liability to the recipient,
+for
+any liability that these contractual assumptions directly impose
+on
+those licensors and authors.
+All other non-permissive additional terms are considered &quot;further
+restrictions&quot; within the meaning of section 10.  If the Program
+as you
+received it, or any part of it, contains a notice stating that
+it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document
+contains
+a further restriction but permits relicensing or conveying under
+this
+License, you may add to a covered work material governed by the
+terms
+of that license document, provided that the further restriction
+does
+not survive such relicensing or conveying.
+If you add terms to a covered work in accord with this section,
+you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+Additional terms, permissive or non-permissive, may be stated
+in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+8. Termination.
+You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate
+or
+modify it is void, and will automatically terminate your rights
+under
+this License (including any patent licenses granted under the
+third
+paragraph of section 11).
+However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly
+and
+finally terminates your license, and (b) permanently, if the
+copyright
+holder fails to notify you of the violation by some reasonable
+means
+prior to 60 days after the cessation.
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of
+the
+violation by some reasonable means, this is the first time you
+have
+received notice of violation of this License (for any work) from
+that
+copyright holder, and you cure the violation prior to 30 days
+after
+your receipt of the notice.
+Termination of your rights under this section does not terminate
+the
+licenses of parties who have received copies or rights from you
+under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the
+same
+material under section 10.
+9. Acceptance Not Required for Having Copies.
+You are not required to accept this License in order to receive
+or
+run a copy of the Program.  Ancillary propagation of a covered
+work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate
+or
+modify any covered work.  These actions infringe copyright if
+you do
+not accept this License.  Therefore, by modifying or propagating
+a
+covered work, you indicate your acceptance of this License to
+do so.
+10. Automatic Licensing of Downstream Recipients.
+Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify
+and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+An &quot;entity transaction&quot; is a transaction transferring control
+of an
+organization, or substantially all assets of one, or subdividing
+an
+organization, or merging organizations.  If propagation of a
+covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party&apos;s predecessor in interest had
+or could
+give under the previous paragraph, plus a right to possession
+of the
+Corresponding Source of the work from the predecessor in interest,
+if
+the predecessor has it or can get it with reasonable efforts.
+You may not impose any further restrictions on the exercise of
+the
+rights granted or affirmed under this License.  For example,
+you may
+not impose a license fee, royalty, or other charge for exercise
+of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging
+that
+any patent claim is infringed by making, using, selling, offering
+for
+sale, or importing the Program or any portion of it.
+11. Patents.
+A &quot;contributor&quot; is a copyright holder who authorizes use under
+this
+License of the Program or a work on which the Program is based.
+The
+work thus licensed is called the contributor&apos;s &quot;contributor version&quot;.
+A contributor&apos;s &quot;essential patent claims&quot; are all patent claims
+owned or controlled by the contributor, whether already acquired
+or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor
+version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.
+For
+purposes of this definition, &quot;control&quot; includes the right to
+grant
+patent sublicenses in a manner consistent with the requirements
+of
+this License.
+Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor&apos;s essential patent claims,
+to
+make, use, sell, offer for sale, import and otherwise run, modify
+and
+propagate the contents of its contributor version.
+In the following three paragraphs, a &quot;patent license&quot; is any
+express
+agreement or commitment, however denominated, not to enforce
+a patent
+(such as an express permission to practice a patent or covenant
+not to
+sue for patent infringement).  To &quot;grant&quot; such a patent license
+to a
+party means to make such an agreement or commitment not to enforce
+a
+patent against the party.
+If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for
+anyone
+to copy, free of charge and under the terms of this License,
+through a
+publicly available network server or other readily accessible
+means,
+then you must either (1) cause the Corresponding Source to be
+so
+available, or (2) arrange to deprive yourself of the benefit
+of the
+patent license for this particular work, or (3) arrange, in a
+manner
+consistent with the requirements of this License, to extend the
+patent
+license to downstream recipients.  &quot;Knowingly relying&quot; means
+you have
+actual knowledge that, but for the patent license, your conveying
+the
+covered work in a country, or your recipient&apos;s use of the covered
+work
+in a country, would infringe one or more identifiable patents
+in that
+country that you have reason to believe are valid.
+If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance
+of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate,
+modify
+or convey a specific copy of the covered work, then the patent
+license
+you grant is automatically extended to all recipients of the
+covered
+work and works based on it.
+A patent license is &quot;discriminatory&quot; if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights
+that are
+specifically granted under this License.  You may not convey
+a covered
+work if you are a party to an arrangement with a third party
+that is
+in the business of distributing software, under which you make
+payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations
+that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+12. No Surrender of Others&apos; Freedom.
+If conditions are imposed on you (whether by court order, agreement
+or
+otherwise) that contradict the conditions of this License, they
+do not
+excuse you from the conditions of this License.  If you cannot
+convey a
+covered work so as to satisfy simultaneously your obligations
+under this
+License and any other pertinent obligations, then as a consequence
+you may
+not convey it at all.  For example, if you agree to terms that
+obligate you
+to collect a royalty for further conveying from those to whom
+you convey
+the Program, the only way you could satisfy both those terms
+and this
+License would be to refrain entirely from conveying the Program.
+13. Use with the GNU Affero General Public License.
+Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into
+a single
+combined work, and to convey the resulting work.  The terms of
+this
+License will continue to apply to the part which is the covered
+work,
+but the special requirements of the GNU Affero General Public
+License,
+section 13, concerning interaction through a network will apply
+to the
+combination as such.
+14. Revised Versions of this License.
+The Free Software Foundation may publish revised and/or new versions
+of
+the GNU General Public License from time to time.  Such new versions
+will
+be similar in spirit to the present version, but may differ in
+detail to
+address new problems or concerns.
+Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU
+General
+Public License &quot;or any later version&quot; applies to it, you have
+the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number
+of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that
+proxy&apos;s
+public statement of acceptance of a version permanently authorizes
+you
+to choose that version for the Program.
+Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed
+on any
+author or copyright holder as a result of your choosing to follow
+a
+later version.
+15. Disclaimer of Warranty.
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED
+BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE
+COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM &quot;AS IS&quot; WITHOUT
+WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT
+LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+16. Limitation of Liability.
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR
+CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY
+OF
+SUCH DAMAGES.
+17. Interpretation of Sections 15 and 16.
+If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with
+the
+Program, unless a warranty or assumption of liability accompanies
+a
+copy of the Program in return for a fee.
+END OF TERMS AND CONDITIONS
+How to Apply These Terms to Your New Programs
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to
+make it
+free software which everyone can redistribute and change under
+these terms.
+To do so, attach the following notices to the program.  It is
+safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at
+least
+the &quot;copyright&quot; line and a pointer to where the full notice is
+found.
+&lt;one line to give the program&apos;s name and a brief idea of what
+it does.&gt;
+Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+This program is free software: you can redistribute it and/or
+modify
+it under the terms of the GNU General Public License as published
+by
+the Free Software Foundation, either version 3 of the License,
+or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.
+Also add information on how to contact you by electronic and
+paper mail.
+If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+&lt;program&gt;  Copyright (C) &lt;year&gt;  &lt;name of author&gt;
+This program comes with ABSOLUTELY NO WARRANTY; for details type
+`show w&apos;.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `show c&apos; for details.
+The hypothetical commands `show w&apos; and `show c&apos; should show the
+appropriate
+parts of the General Public License.  Of course, your program&apos;s
+commands
+might be different; for a GUI interface, you would use an &quot;about
+box&quot;.
+You should also get your employer (if you work as a programmer)
+or school,
+if any, to sign a &quot;copyright disclaimer&quot; for the program, if
+necessary.
+For more information on this, and how to apply and follow the
+GNU GPL, see
+&lt;http://www.gnu.org/licenses/&gt;.
+The GNU General Public License does not permit incorporating
+your program
+into proprietary programs.  If your program is a subroutine library,
+you
+may consider it more useful to permit linking proprietary applications
+with
+the library.  If this is what you want to do, use the GNU Lesser
+General
+Public License instead of this License.  But first, please read
+&lt;http://www.gnu.org/philosophy/why-not-lgpl.html&gt;.
+   </license>
+
+   <requires>
+      <import plugin="net.sourceforge.vrapper.eclipse" version="0.69.20160629" match="greaterOrEqual"/>
+      <import feature="net.sourceforge.vrapper" version="0.69.20160629"/>
+   </requires>
+
+   <plugin
+         id="net.sourceforge.vrapper.plugin.sneak"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/.classpath
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/.project
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>net.sourceforge.vrapper.plugin.sneak</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/META-INF/MANIFEST.MF
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Vrapper Sneak Plug-in
+Bundle-SymbolicName: net.sourceforge.vrapper.plugin.sneak;singleton:=true
+Bundle-Version: 0.71.20160927
+Require-Bundle: net.sourceforge.vrapper.core;bundle-version="0.71.20160927",
+ net.sourceforge.vrapper.eclipse;bundle-version="0.71.20160927"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Eclipse-BuddyPolicy: dependent

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/build.properties
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               plugin.xml,\
+               .

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/plugin.xml
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/plugin.xml
@@ -25,4 +25,12 @@
             listener-class="net.sourceforge.vrapper.plugin.sneak.provider.SneakLifecycleListener">
       </lifecycle-listener>
    </extension>
+   <extension
+         point="net.sourceforge.vrapper.eclipse.pstop">
+      <textobject-provider
+            id="net.sourceforge.vrapper.plugin.sneak.textobject-provider"
+            name="net.sourceforge.vrapper.plugin.sneak.textobject-provider"
+            provider-class="net.sourceforge.vrapper.plugin.sneak.provider.SneakTextObjectProvider">
+      </textobject-provider>
+   </extension>
 </plugin>

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/plugin.xml
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/plugin.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="net.sourceforge.vrapper.eclipse.pssp">
+      <keymap-provider
+            id="net.sourceforge.vrapper.plugin.sneak.provider.SneakStateProvider"
+            name="vim-sneak State Provider"
+            priority="20"
+            provider-class="net.sourceforge.vrapper.plugin.sneak.provider.SneakStateProvider">
+      </keymap-provider>
+   </extension>
+   <extension
+         point="net.sourceforge.vrapper.eclipse.psmp">
+      <mode-provider
+            id="net.sourceforge.vrapper.plugin.sneak.provider.SneakModeProvider"
+            name="vim-sneak Mode Provider"
+            provider-class="net.sourceforge.vrapper.plugin.sneak.provider.SneakModeProvider">
+      </mode-provider>
+   </extension>
+   <extension
+         point="net.sourceforge.vrapper.eclipse.lifecyclelistener">
+      <lifecycle-listener
+            id="net.sourceforge.vrapper.plugin.sneak.eclipse.lifecycle-listener"
+            listener-class="net.sourceforge.vrapper.plugin.sneak.provider.SneakLifecycleListener">
+      </lifecycle-listener>
+   </extension>
+</plugin>

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/SneakTextObject.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/SneakTextObject.java
@@ -1,0 +1,101 @@
+package net.sourceforge.vrapper.plugin.sneak.commands;
+
+import net.sourceforge.vrapper.platform.Configuration;
+import net.sourceforge.vrapper.platform.CursorService;
+import net.sourceforge.vrapper.platform.SearchAndReplaceService;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakState;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakStateManager;
+import net.sourceforge.vrapper.plugin.sneak.modes.SneakInputMode;
+import net.sourceforge.vrapper.utils.ContentType;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.Search;
+import net.sourceforge.vrapper.utils.SearchResult;
+import net.sourceforge.vrapper.utils.StartEndTextRange;
+import net.sourceforge.vrapper.utils.TextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.AbstractTextObject;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+
+public class SneakTextObject extends AbstractTextObject {
+
+    /** Cached search keyword so that . */
+    private Search searchKeyword;
+    private SneakStateManager stateManager;
+    private String searchString;
+    private boolean sneakBackwards;
+
+    /**
+     * Create a sneak text object.
+     * @param sneakStateManager Injects a particular type of {@link SneakStateManager}.
+     * @param searchString the search keyword. This is passed in as a string rather than a Search
+     *     instance because the Vrapper keybind state machine hasn't got access to user settings
+     *     like 'ignorecase' or the last sneak keyword.
+     */
+    public SneakTextObject(SneakStateManager sneakStateManager, String searchString,
+            boolean sneakBackwards) {
+        this.stateManager = sneakStateManager;
+        this.searchString = searchString;
+        this.sneakBackwards = sneakBackwards;
+        if (searchString == null) {
+            throw new NullPointerException("Search string parameter cannot be null.");
+        }
+    }
+
+    @Override
+    public TextRange getRegion(EditorAdaptor editorAdaptor, int count)
+            throws CommandExecutionException {
+        Position initialPosition = editorAdaptor.getPosition();
+        if (searchKeyword == null) {
+            if (searchString.isEmpty()) {
+                SneakState sneakState;
+                try {
+                    sneakState = stateManager.getSneakState(editorAdaptor);
+                } catch (VrapperPlatformException e) {
+                    // No state present?!?
+                    return new StartEndTextRange(initialPosition, initialPosition);
+                }
+                searchKeyword = sneakState.getSneakSearch();
+            } else {
+                searchKeyword = SneakInputMode.constructSearchKeyword(editorAdaptor, searchString,
+                        sneakBackwards);
+            }
+        }
+        CursorService cursorService = editorAdaptor.getCursorService();
+        SearchAndReplaceService searchAndReplaceService = editorAdaptor.getSearchAndReplaceService();
+
+        Position result = null;
+
+        // Move position so we don't hit current match again. Shifting clips to file boundaries.
+        Position position = initialPosition;
+        int offsetShift = (searchKeyword.isBackward() ? -1 : 1);
+        position = cursorService.shiftPositionForModelOffset(position.getModelOffset(),
+                offsetShift, true);
+
+        SearchResult searchResult = searchAndReplaceService.find(searchKeyword, position);
+
+        if (count == NO_COUNT_GIVEN) {
+            count = 1;
+        }
+        int nFound = 0;
+        while (searchResult.isFound() && nFound < count) {
+            result = searchResult.getLeftBound();
+            // Shift and find again
+            position = cursorService.shiftPositionForModelOffset(
+                    searchResult.getLeftBound().getModelOffset(), offsetShift, true);
+            searchResult = searchAndReplaceService.find(searchKeyword, position);
+            nFound++;
+        }
+        if (result == null) {
+            return new StartEndTextRange(initialPosition, initialPosition);
+        }
+
+        // This find is exclusive border type so we don't need any extra work
+        return new StartEndTextRange(initialPosition, result);
+    }
+
+    @Override
+    public ContentType getContentType(Configuration configuration) {
+        return ContentType.TEXT;
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/motions/JumpMotionDecorator.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/motions/JumpMotionDecorator.java
@@ -1,0 +1,49 @@
+package net.sourceforge.vrapper.plugin.sneak.commands.motions;
+
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.BorderPolicy;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.motions.AbstractMotion;
+import net.sourceforge.vrapper.vim.commands.motions.Motion;
+import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+
+/**
+ * Makes a Motion declare itself as one which jumps.
+ */
+public class JumpMotionDecorator extends AbstractMotion implements Motion {
+    protected Motion delegate;
+
+    public JumpMotionDecorator(Motion motion) {
+        delegate = motion;
+    }
+
+    public Motion withCount(int count) {
+        return new JumpMotionDecorator(delegate.withCount(count));
+    }
+
+    public int getCount() {
+        return delegate.getCount();
+    }
+
+    public Position destination(EditorAdaptor editorAdaptor) throws CommandExecutionException {
+        return delegate.destination(editorAdaptor);
+    }
+
+    public BorderPolicy borderPolicy() {
+        return delegate.borderPolicy();
+    }
+
+    public StickyColumnPolicy stickyColumnPolicy() {
+        return delegate.stickyColumnPolicy();
+    }
+
+    public boolean isJump() {
+        return true;
+    }
+
+    @Override
+    public <T> T getAdapter(Class<T> type) {
+        return delegate.getAdapter(type);
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/motions/SneakMotion.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/motions/SneakMotion.java
@@ -1,9 +1,11 @@
 package net.sourceforge.vrapper.plugin.sneak.commands.motions;
 
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakCharOffset;
 import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakState;
 import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakStateManager;
 import net.sourceforge.vrapper.utils.Position;
 import net.sourceforge.vrapper.utils.Search;
+import net.sourceforge.vrapper.utils.TextRange;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.commands.BorderPolicy;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
@@ -19,17 +21,16 @@ public class SneakMotion extends CountAwareMotion implements NavigatingMotion {
     /** Right boundary for sneak-column mode. */
     private int columnRight;
     private Search searchKeyword;
-
-    public SneakMotion(SneakStateManager sneakStateManager, Search searchKeyword) {
-        this(sneakStateManager, searchKeyword, -1, -1);
-    }
+    /** Offset to correct jumps when using the f/F/t/T alternatives. */
+    private SneakCharOffset searchOffset;
 
     public SneakMotion(SneakStateManager sneakStateManager, Search searchKeyword, int columnLeft,
-            int columnRight) {
+            int columnRight, SneakCharOffset searchOffset) {
         this.stateManager = sneakStateManager;
         this.searchKeyword = searchKeyword;
         this.columnLeft = columnLeft;
         this.columnRight = columnRight;
+        this.searchOffset = searchOffset;
     }
 
     @Override
@@ -39,7 +40,7 @@ public class SneakMotion extends CountAwareMotion implements NavigatingMotion {
 
     @Override
     public BorderPolicy borderPolicy() {
-        return BorderPolicy.EXCLUSIVE;
+        return isFfTtMode() ? BorderPolicy.INCLUSIVE : BorderPolicy.EXCLUSIVE;
     }
 
     @Override
@@ -51,7 +52,7 @@ public class SneakMotion extends CountAwareMotion implements NavigatingMotion {
     public Position destination(EditorAdaptor editorAdaptor, int count)
             throws CommandExecutionException {
 
-        Position result = null;
+        TextRange match = null;
 
         if (count <= NO_COUNT_GIVEN) {
             count = 1;
@@ -64,24 +65,44 @@ public class SneakMotion extends CountAwareMotion implements NavigatingMotion {
         if (state.isSearchStateUsable(searchKeyword, columnLeft, columnRight)) {
 
             if (state.isPreviousMatchStateOnSameKeywordAndDirection(searchKeyword)) {
-                result = state.sneakToNextMatch(editorAdaptor, count);
+                match = state.sneakToNextMatch(editorAdaptor, count);
             } else {
                 state.reverseSearchDirection(editorAdaptor);
-                result = state.sneakToNextMatch(editorAdaptor, count);
+                match = state.sneakToNextMatch(editorAdaptor, count);
             }
         } else {
             state.deactivateSneak(editorAdaptor.getHighlightingService());
             state.runNewSearch(editorAdaptor, count, searchKeyword, columnLeft, columnRight);
-            result = state.sneakToNextMatch(editorAdaptor, count);
+            match = state.sneakToNextMatch(editorAdaptor, count);
         }
 
+        Position result;
+        if (searchOffset == null) {
+            result = match.getLeftBound();
+        } else {
+            result = searchOffset.apply(editorAdaptor, match);
+        }
 
         return result;
     }
 
     @Override
     public SneakMotion reverse() {
-        return new SneakMotion(stateManager, searchKeyword.reverse(), columnLeft, columnRight);
+
+        SneakCharOffset reversedOffset = searchOffset;
+        if (searchOffset != null) {
+            reversedOffset = searchOffset.reverse();
+        }
+
+        return new SneakMotion(stateManager, searchKeyword.reverse(), columnLeft, columnRight,
+                reversedOffset);
+    }
+
+    /**
+     * @return <code>true</code> when we're dealing with sneak_f/F/t/T.
+     */
+    private boolean isFfTtMode() {
+        return searchOffset != null;
     }
 
     @Override

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/motions/SneakMotion.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/motions/SneakMotion.java
@@ -1,0 +1,102 @@
+package net.sourceforge.vrapper.plugin.sneak.commands.motions;
+
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakState;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakStateManager;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.Search;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.BorderPolicy;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.motions.CountAwareMotion;
+import net.sourceforge.vrapper.vim.commands.motions.NavigatingMotion;
+import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
+
+public class SneakMotion extends CountAwareMotion implements NavigatingMotion {
+
+    private SneakStateManager stateManager;
+
+    private int columnLeft;
+    /** Right boundary for sneak-column mode. */
+    private int columnRight;
+    private Search searchKeyword;
+
+    public SneakMotion(SneakStateManager sneakStateManager, Search searchKeyword) {
+        this(sneakStateManager, searchKeyword, -1, -1);
+    }
+
+    public SneakMotion(SneakStateManager sneakStateManager, Search searchKeyword, int columnLeft,
+            int columnRight) {
+        this.stateManager = sneakStateManager;
+        this.searchKeyword = searchKeyword;
+        this.columnLeft = columnLeft;
+        this.columnRight = columnRight;
+    }
+
+    @Override
+    public boolean isBackward() {
+        return searchKeyword.isBackward();
+    }
+
+    @Override
+    public BorderPolicy borderPolicy() {
+        return BorderPolicy.EXCLUSIVE;
+    }
+
+    @Override
+    public StickyColumnPolicy stickyColumnPolicy() {
+        return StickyColumnPolicy.ON_CHANGE;
+    }
+
+    @Override
+    public Position destination(EditorAdaptor editorAdaptor, int count)
+            throws CommandExecutionException {
+
+        Position result = null;
+
+        if (count <= NO_COUNT_GIVEN) {
+            count = 1;
+        }
+
+        SneakState state = stateManager.getSneakState(editorAdaptor);
+
+        stateManager.markSneakActive(editorAdaptor);
+
+        if (state.isSearchStateUsable(searchKeyword, columnLeft, columnRight)) {
+
+            if (state.isPreviousMatchStateOnSameKeywordAndDirection(searchKeyword)) {
+                result = state.sneakToNextMatch(editorAdaptor, count);
+            } else {
+                state.reverseSearchDirection(editorAdaptor);
+                result = state.sneakToNextMatch(editorAdaptor, count);
+            }
+        } else {
+            state.deactivateSneak(editorAdaptor.getHighlightingService());
+            state.runNewSearch(editorAdaptor, count, searchKeyword, columnLeft, columnRight);
+            result = state.sneakToNextMatch(editorAdaptor, count);
+        }
+
+
+        return result;
+    }
+
+    @Override
+    public SneakMotion reverse() {
+        return new SneakMotion(stateManager, searchKeyword.reverse(), columnLeft, columnRight);
+    }
+
+    @Override
+    public NavigatingMotion repetition() {
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getAdapter(Class<T> type) {
+        if (NavigatingMotion.class.equals(type)) {
+            return (T) this;
+        } else if (SneakMotion.class.equals(type)) {
+            return (T) this;
+        }
+        return null;
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/EditorAdaptorStateManager.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/EditorAdaptorStateManager.java
@@ -1,0 +1,55 @@
+package net.sourceforge.vrapper.plugin.sneak.commands.utils;
+
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+import net.sourceforge.vrapper.plugin.sneak.modes.SneakInputMode;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.modes.EditorMode;
+
+/**
+ * This implementation of {@link SneakStateManager} will extract the current sneak state from the
+ * {@link SneakInputMode} in the current editor.
+ */
+public class EditorAdaptorStateManager implements SneakStateManager {
+
+    /**
+     * Retrieves the current sneak state.
+     * @return {@link SneakState}
+     * @throws VrapperPlatformException when sneak hasn't been initialized yet.
+     */
+    @Override
+    public SneakState getSneakState(EditorAdaptor editorAdaptor) {
+        SneakState result = null;
+        EditorMode mode = editorAdaptor.getMode(SneakInputMode.NAME);
+        // Note that the mode could be null
+        if (mode instanceof SneakInputMode) {
+            SneakInputMode sneakMode = (SneakInputMode) mode;
+            result = sneakMode.getPreviousState();
+            return result;
+        } else {
+            throw new VrapperPlatformException("Sneak input mode never got initialized");
+        }
+    }
+
+    @Override
+    public void markSneakActive(EditorAdaptor editorAdaptor) {
+
+        SneakState sneakState = getSneakState(editorAdaptor);
+        sneakState.keepSneakActive();
+    }
+
+    @Override
+    public void markSneakInactive(EditorAdaptor editorAdaptor) {
+        
+        SneakState sneakState = getSneakState(editorAdaptor);
+        sneakState.deactivateSneak(editorAdaptor.getHighlightingService());
+    }
+
+    @Override
+    public void increaseCounters(EditorAdaptor editorAdaptor) {
+
+        SneakState sneakState = getSneakState(editorAdaptor);
+
+        long counter = sneakState.getGlobalEventCounter() + 1;
+        sneakState.globalEventCounter = counter;
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/SneakCharOffset.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/SneakCharOffset.java
@@ -1,0 +1,64 @@
+package net.sourceforge.vrapper.plugin.sneak.commands.utils;
+
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.TextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+/**
+ * Defines an additional char offset to simulate t/T in vim-sneak.
+ */
+public class SneakCharOffset {
+    public static final SneakCharOffset NONE = new SneakCharOffset(0);
+    private final int offset;
+
+    public SneakCharOffset(int offset) {
+        this.offset = offset;
+    }
+
+    public Position apply(EditorAdaptor editorAdaptor, TextRange sneakMatch) {
+        if (offset == 0) {
+            return sneakMatch.getLeftBound();
+        }
+        Position start = sneakMatch.getLeftBound();
+        return editorAdaptor.getCursorService().shiftPositionForModelOffset(start.getModelOffset(),
+                offset, true);
+    }
+
+    public SneakCharOffset reverse() {
+        if (offset == 0) {
+            return NONE;
+        } else {
+            return new SneakCharOffset(-offset);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + offset;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SneakCharOffset other = (SneakCharOffset) obj;
+        if (offset != other.offset)
+            return false;
+        return true;
+    }
+
+    public boolean equalsAmountOfChars(SneakCharOffset searchOffset) {
+        return Math.abs(offset) == Math.abs(searchOffset.offset);
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/SneakState.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/SneakState.java
@@ -1,0 +1,311 @@
+package net.sourceforge.vrapper.plugin.sneak.commands.utils;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.platform.CursorService;
+import net.sourceforge.vrapper.platform.HighlightingService;
+import net.sourceforge.vrapper.platform.SearchAndReplaceService;
+import net.sourceforge.vrapper.plugin.sneak.commands.motions.SneakMotion;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.utils.Search;
+import net.sourceforge.vrapper.utils.SearchResult;
+import net.sourceforge.vrapper.utils.TextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.VrapperEventListener;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.register.RegisterManager;
+
+/**
+ * Stores information about sneak's status in a given editor.
+ * This has nothing to do with Vrapper keymap {@link State}s.
+ */
+public class SneakState {
+
+    /** Max size for the nextMatches or previousMatches lists (separately). */
+    private static final int MAX_SNEAK_CACHE_SIZE = 500;
+
+    /** Minimal number of items which should be in the cache. */
+    private static final int MIN_SNEAK_CACHE_PREFILL = 250;
+
+    private static final String SNEAK_HIGHLIGHT_TYPE = "net.sourceforge.vrapper.eclipse.incsearchhighlight";
+
+    private static final String NOT_FOUND_MESSAGE = "'%s' not found";
+
+    /**
+     * This indicates whether the previousMatches list contains all possible results or whether
+     * we need to fill the buffer for more.
+     */
+    private boolean allPreviousMatchesFound;
+    /**
+     * This indicates whether the nextMatches list contains all possible results or whether
+     * we need to fill the buffer for more.
+     */
+    private boolean allNextMatchesFound;
+
+    /** Left boundary for sneak-column mode. */
+    private int columnLeft;
+    /** Right boundary for sneak-column mode. */
+    private int columnRight;
+    private LinkedList<Object> nextHighlights;
+    private LinkedList<TextRange> nextMatches;
+    private LinkedList<TextRange> previousMatches;
+
+    private Search sneakSearch;
+
+    /*
+     * Shared with SneakStateManager
+     */
+    boolean isSneaking;
+    long globalEventCounter;
+    long lastSneakCommandEventCounter;
+
+    /**
+     * Default constructor, marking sneak inactive.
+     */
+    public SneakState() {
+        isSneaking = false;
+        lastSneakCommandEventCounter = -1;
+        columnLeft = -1;
+        columnRight = -1;
+        nextHighlights = new LinkedList<Object>();
+        nextMatches = new LinkedList<TextRange>();
+        previousMatches = new LinkedList<TextRange>();
+    }
+
+    /**
+     * Retrieves the search keyword for which the current cache data is calculated. The cache should
+     * be cleared every time this keyword is changed, either through SneakInputMode or through a
+     * different editor putting a fresh {@link SneakMotion} into the {@link RegisterManager}.
+     * @return the last sneak search. Can be <code>null</code> if {@link #isSneaking()} returns
+     * <code>false</code>.
+     */
+    public Search getSneakSearch() {
+        return sneakSearch;
+    }
+
+    /**
+     * This event counter is used to keep track of how often the 
+     * {@link VrapperEventListener#commandAboutToExecute(net.sourceforge.vrapper.vim.modes.EditorMode)}
+     * function has been called in the current editor.
+     */
+    public long getGlobalEventCounter() {
+        return globalEventCounter;
+    }
+
+    /**
+     * This counter tells us if the last event on {@link VrapperEventListener} got handled by sneak.
+     * It is the {@link SneakStateManager}'s responsibility to sync it with the the global event
+     * counter when
+     * {@link SneakStateManager#markSneakActive(net.sourceforge.vrapper.vim.EditorAdaptor, boolean, List)}
+     * is called.
+     */
+    public long getLastSneakCommandEventCounter() {
+        return lastSneakCommandEventCounter;
+    }
+
+    /**
+     * Whether the last command was also a sneak command. Useful to know if the highlighting can be
+     * just slightly tweaked or if it needs to be recalculated from scratch.
+     */
+    public boolean isSneaking() {
+        return isSneaking;
+    }
+
+    private boolean hasHighlightsActive() {
+        return ! nextHighlights.isEmpty();
+    }
+
+    public void deactivateSneak(HighlightingService highlightingService) {
+        if (hasHighlightsActive()) {
+            clearHighlights(highlightingService, 0, nextHighlights.size());
+        }
+        isSneaking = false;
+        nextMatches.clear();
+        previousMatches.clear();
+        allPreviousMatchesFound = false;
+        allNextMatchesFound = false;
+    }
+
+    public void keepSneakActive() {
+        lastSneakCommandEventCounter = globalEventCounter;
+    }
+
+    protected void clearHighlights(HighlightingService highlightingService,
+            int startindex, int numberOfItems) {
+        List<Object> highlightsToRemove;
+        if (startindex == 0 && numberOfItems >= nextHighlights.size()) {
+            highlightsToRemove = nextHighlights;
+        } else {
+           highlightsToRemove = nextHighlights.subList(startindex, numberOfItems);
+        }
+
+        highlightingService.removeHighlights(highlightsToRemove);
+        highlightsToRemove.clear();
+    }
+
+    /**
+     * Whether the previous search results can be reused, which is only the case if the sneak
+     * parameters haven't changed and the editor hasn't been modified.
+     */
+    public boolean isSearchStateUsable(Search searchKeyword, int columnLeft, int columnRight) {
+        return isSneaking
+                && searchKeyword.equalsIgnoreDirection(this.sneakSearch)
+                && columnLeft == this.columnLeft
+                && columnRight == this.columnRight;
+    }
+
+    public boolean isPreviousMatchStateOnSameKeywordAndDirection(Search searchKeyword) {
+        return searchKeyword.equals(this.sneakSearch);
+    }
+
+    public void reverseSearchDirection(EditorAdaptor editorAdaptor) {
+
+        HighlightingService highlightingService = editorAdaptor.getHighlightingService();
+        clearHighlights(highlightingService, 0, nextHighlights.size());
+
+        sneakSearch = sneakSearch.reverse();
+
+        LinkedList<TextRange> tempForReversal = previousMatches;
+        previousMatches = nextMatches;
+        nextMatches = tempForReversal;
+
+        boolean tempForBooleanReversal = allPreviousMatchesFound;
+        allPreviousMatchesFound = allNextMatchesFound;
+        allNextMatchesFound = tempForBooleanReversal;
+
+        highlightAdditionalMatches(nextMatches, highlightingService);
+    }
+
+    public void runNewSearch(EditorAdaptor editorAdaptor, int count, Search searchKeyword,
+            int columnLeft, int columnRight) {
+        HighlightingService highlightingService = editorAdaptor.getHighlightingService();
+        deactivateSneak(highlightingService);
+
+        this.sneakSearch = searchKeyword;
+        this.columnLeft = columnLeft;
+        this.columnRight = columnRight;
+
+        findNextMatches(editorAdaptor, editorAdaptor.getPosition(), MIN_SNEAK_CACHE_PREFILL + count);
+    }
+
+    private void findNextMatches(EditorAdaptor editorAdaptor, Position startPosition,
+            int additionalItemCount) {
+        if (allNextMatchesFound) {
+            return;
+        }
+
+        int offsetShift = (sneakSearch.isBackward() ? -1 : 1);
+        SearchAndReplaceService searchAndReplaceService = editorAdaptor.getSearchAndReplaceService();
+        CursorService cursorService = editorAdaptor.getCursorService();
+
+        List<TextRange> searchHits = new ArrayList<TextRange>();
+
+        // Move position so we don't hit current match again. Shifting clips to file boundaries.
+        Position position;
+        position = cursorService.shiftPositionForModelOffset(startPosition.getModelOffset(),
+                offsetShift, true);
+
+        SearchResult searchResult = searchAndReplaceService.find(sneakSearch, position);
+
+        // [TODO] Implement sneak's "column search"
+
+        int countResults = 0;
+        while (searchResult.isFound() && countResults < additionalItemCount) {
+            searchHits.add(searchResult);
+            position = cursorService.shiftPositionForModelOffset(
+                    searchResult.getLeftBound().getModelOffset(), offsetShift, true);
+            searchResult = searchAndReplaceService.find(sneakSearch, position);
+            countResults++;
+        }
+        storeAdditionalMatches(searchResult, searchHits);
+        highlightAdditionalMatches(searchHits, editorAdaptor.getHighlightingService());
+    }
+
+    private void storeAdditionalMatches(SearchResult lastSearchResult,
+            List<TextRange> additionalMatches) {
+        if ( ! lastSearchResult.isFound()) {
+            allNextMatchesFound = true;
+        }
+        nextMatches.addAll(additionalMatches);
+    }
+
+    private void highlightAdditionalMatches(List<TextRange> searchHits,
+            HighlightingService highlightingService) {
+        List<Object> highlights;
+        highlights = highlightingService.highlightRegions(SNEAK_HIGHLIGHT_TYPE, "Sneak hit", searchHits);
+        nextHighlights.addAll(highlights);
+    }
+
+    public Position sneakToNextMatch(EditorAdaptor editorAdaptor, int count) throws CommandExecutionException {
+
+        prepareNextMatches(editorAdaptor, count);
+
+        if (nextMatches.size() == 0) {
+            throw new CommandExecutionException(String.format(NOT_FOUND_MESSAGE,
+                    sneakSearch.getKeyword()));
+        }
+        if (nextMatches.size() < count) {
+            // Simply jump to last possible match
+            count = nextMatches.size();
+        }
+        Position result = nextMatches.get(count - 1).getLeftBound();
+        transferNextMatchesToPreviousMatches(editorAdaptor, count);
+
+        isSneaking = true;
+
+        trimNextMatchesCache(editorAdaptor);
+
+        return result;
+    }
+
+    private void prepareNextMatches(EditorAdaptor editorAdaptor, int count) {
+        // Add <count> new entries to nextMatches to keep it filled
+        if ( ! allNextMatchesFound) {
+            TextRange lastMatch = nextMatches.peekLast();
+            Position searchStartPosition;
+            // nextMatches may be empty
+            if (lastMatch == null) {
+                searchStartPosition = editorAdaptor.getPosition();
+            } else {
+                searchStartPosition = lastMatch.getLeftBound();
+            }
+            int prefillFetchCount = MIN_SNEAK_CACHE_PREFILL - nextMatches.size() + count;
+            int itemsToAddCount = Math.max(count, prefillFetchCount);
+            findNextMatches(editorAdaptor, searchStartPosition, itemsToAddCount);
+        }
+
+        // Transfer current position if it is the next match (this happens when reversing)
+        if (nextMatches.size() > 0
+                && editorAdaptor.getPosition().equals(nextMatches.getFirst().getLeftBound())) {
+            transferNextMatchesToPreviousMatches(editorAdaptor, 1);
+        }
+    }
+
+    private void transferNextMatchesToPreviousMatches(EditorAdaptor editorAdaptor, int count) {
+        // These matches need to be moved in reversed order so we can't use subList
+        for (int i = 0; i < count; i++) {
+            previousMatches.addFirst(nextMatches.remove());
+        }
+        clearHighlights(editorAdaptor.getHighlightingService(), 0, count);
+    }
+    
+    private void trimNextMatchesCache(EditorAdaptor editorAdaptor) {
+        // This can happen when we just did a jump like 500;
+        if (nextMatches.size() > MAX_SNEAK_CACHE_SIZE) {
+            List<TextRange> itemsToTrim = nextMatches.subList(MAX_SNEAK_CACHE_SIZE, nextMatches.size());
+            List<Object> highlightsToTrim = nextHighlights.subList(MAX_SNEAK_CACHE_SIZE, nextHighlights.size());
+            editorAdaptor.getHighlightingService().removeHighlights(highlightsToTrim);
+            highlightsToTrim.clear();
+            itemsToTrim.clear();
+            
+            allNextMatchesFound = false;
+        }
+        if (previousMatches.size() > MAX_SNEAK_CACHE_SIZE) {
+            List<TextRange> itemsToTrim = previousMatches.subList(MAX_SNEAK_CACHE_SIZE, previousMatches.size());
+            itemsToTrim.clear();
+        }
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/SneakStateManager.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/commands/utils/SneakStateManager.java
@@ -1,0 +1,44 @@
+package net.sourceforge.vrapper.plugin.sneak.commands.utils;
+
+import java.util.List;
+
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+import net.sourceforge.vrapper.utils.Position;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+/**
+ * Interface to abstract away the retrieval of Sneak's current state. This should help during
+ * testing as the sneak mode might otherwise not be regisetered in the {@link EditorAdaptor}
+ * instance.
+ */
+public interface SneakStateManager {
+    /**
+     * Read the current sneak state for this editor. This object is a clone of the actual state so
+     * modifying it has no effect.
+     * @param editorAdaptor {@link EditorAdaptor} for the current editor.
+     * @return {@link SneakState}
+     * @throws VrapperPlatformException when sneak hasn't been initialized yet.
+     */
+    public SneakState getSneakState(EditorAdaptor editorAdaptor);
+
+    /**
+     * Write the current sneak state.
+     * @param editorAdaptor {@link EditorAdaptor} for the current editor.
+     * @param backward boolean whether sneak moves toward the file start (necessary to know if
+     *      highlighting needs to be calculated from scratch).
+     * @param highlighting {@link List} of Object with current highligting state for later cleanup.
+     * @param positions {@link List} of {@link Position}s to cache the possible target positions.
+     */
+    public void markSneakActive(EditorAdaptor editorAdaptor);
+
+    /**
+     * Stops the current sneak highlighting.
+     * @param editorAdaptor {@link EditorAdaptor} for the current editor.
+     */
+    public void markSneakInactive(EditorAdaptor editorAdaptor);
+
+    /**
+     * Increases the event counters for detecting whether sneak should remain active.
+     */
+    public void increaseCounters(EditorAdaptor editorAdaptor);
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/keymap/SneakFindCharactersTextObjectState.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/keymap/SneakFindCharactersTextObjectState.java
@@ -1,0 +1,60 @@
+package net.sourceforge.vrapper.plugin.sneak.keymap;
+
+import net.sourceforge.vrapper.keymap.KeyStroke;
+import net.sourceforge.vrapper.keymap.SimpleTransition;
+import net.sourceforge.vrapper.keymap.SpecialKey;
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.Transition;
+import net.sourceforge.vrapper.plugin.sneak.commands.SneakTextObject;
+import net.sourceforge.vrapper.plugin.sneak.modes.SneakInputMode;
+import net.sourceforge.vrapper.vim.commands.TextObject;
+
+/**
+ * This special state replaces the input logic of {@link SneakInputMode} for when we can't easily
+ * switch modes, e.g. when invoking an operator.
+ */
+public class SneakFindCharactersTextObjectState implements State<TextObject> {
+
+    public static State<TextObject> forwards(int count) {
+        return new SneakFindCharactersTextObjectState(false, count, "");
+    }
+
+    public static State<TextObject> backwards(int count) {
+        return new SneakFindCharactersTextObjectState(true, count, "");
+    }
+
+    private final boolean sneakBackwards;
+    private final int charactersNeeded;
+    private final String characters;
+
+    public SneakFindCharactersTextObjectState(boolean sneakBackwards, int charactersNeeded, String characters) {
+        this.sneakBackwards = sneakBackwards;
+        this.charactersNeeded = charactersNeeded;
+        this.characters = characters;
+    }
+
+    @Override
+    public Transition<TextObject> press(KeyStroke stroke) {
+        if (stroke.getSpecialKey() == SpecialKey.RETURN) {
+            return new SimpleTransition<TextObject>(
+                    new SneakTextObject(SneakInputMode.STATEMANAGER, characters, sneakBackwards));
+
+        // [NOTE] We might enter this else when using AltGr on Windows, ignoring user input
+        } else if (stroke.getCharacter() == KeyStroke.SPECIAL_KEY || stroke.withCtrlKey()) {
+            return null;
+        }
+        String newCharacters = characters + stroke.getCharacter();
+        if (charactersNeeded <= 1) {
+            return new SimpleTransition<TextObject>(
+                    new SneakTextObject(SneakInputMode.STATEMANAGER, newCharacters, sneakBackwards));
+        } else {
+            return new SimpleTransition<TextObject>(new SneakFindCharactersTextObjectState(sneakBackwards,
+                    charactersNeeded - 1, newCharacters));
+        }
+    }
+
+    @Override
+    public State<TextObject> union(State<TextObject> other) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/ChangeToSneakModeCommand.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/ChangeToSneakModeCommand.java
@@ -1,0 +1,83 @@
+package net.sourceforge.vrapper.plugin.sneak.modes;
+
+import net.sourceforge.vrapper.utils.VimUtils;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.AbstractCommand;
+import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.SuspendVisualModeCommand;
+import net.sourceforge.vrapper.vim.modes.ModeSwitchHint;
+import net.sourceforge.vrapper.vim.modes.WithCountHint;
+
+public class ChangeToSneakModeCommand extends AbstractCommand {
+    private final ModeSwitchHint[] args;
+
+    public static Command withoutHints() {
+        return new ChangeToSneakModeCommand();
+    }
+
+    public static Command withHints(ModeSwitchHint...hints) {
+        return new ChangeToSneakModeCommand(hints);
+    }
+
+    public static Command backwards(ModeSwitchHint...hints) {
+        ModeSwitchHint[] hintsAndBackwards = new ModeSwitchHint[hints.length + 1];
+        System.arraycopy(hints, 0, hintsAndBackwards, 0, hints.length);
+        int indexOfLastHint = hints.length /* -1 + 1 */;
+
+        hintsAndBackwards[indexOfLastHint] = SneakInputMode.SNEAK_BACKWARDS;
+
+        return new ChangeToSneakModeCommand(hintsAndBackwards);
+    }
+
+    public static Command fromVisual(ModeSwitchHint...hints) {
+        ModeSwitchHint[] hintsFromVisual = new ModeSwitchHint[hints.length + 1];
+        System.arraycopy(hints, 0, hintsFromVisual, 0, hints.length);
+        int indexOfLastHint = hints.length /* -1 + 1 */;
+
+        hintsFromVisual[indexOfLastHint] = SneakInputMode.FROM_VISUAL;
+
+        return new ChangeToSneakModeCommand(hintsFromVisual);
+    }
+
+    public static Command backwardsAndFromVisual(ModeSwitchHint...hints) {
+        ModeSwitchHint[] hintsAndBackwardsFromVisual = new ModeSwitchHint[hints.length + 2];
+        System.arraycopy(hints, 0, hintsAndBackwardsFromVisual, 0, hints.length);
+        int indexOfSecondLastHint = hints.length /* -1 + 1 */;
+
+        hintsAndBackwardsFromVisual[indexOfSecondLastHint] = SneakInputMode.FROM_VISUAL;
+        hintsAndBackwardsFromVisual[indexOfSecondLastHint + 1] = SneakInputMode.SNEAK_BACKWARDS;
+
+        return new ChangeToSneakModeCommand(hintsAndBackwardsFromVisual);
+    }
+
+
+    protected ChangeToSneakModeCommand(ModeSwitchHint... args) {
+        this.args = args;
+    }
+
+    @Override
+    public void execute(EditorAdaptor editorAdaptor) throws CommandExecutionException {
+
+        if (VimUtils.findModeHint(SneakInputMode.FROM_VISUAL.getClass(), args) != null) {
+            SuspendVisualModeCommand.INSTANCE.execute(editorAdaptor);
+        }
+        editorAdaptor.changeMode(SneakInputMode.NAME, args);
+    }
+
+    @Override
+    public Command repetition() {
+        return null;
+    }
+
+    @Override
+    public Command withCount(int count) {
+        ModeSwitchHint[] hintsWithCount = new ModeSwitchHint[args.length + 1];
+        System.arraycopy(args, 0, hintsWithCount, 0, args.length);
+        int indexOfLastHint = args.length /* -1 + 1 */;
+
+        hintsWithCount[indexOfLastHint] = new WithCountHint(count);
+
+        return new ChangeToSneakModeCommand(hintsWithCount);
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/SneakCommandListener.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/SneakCommandListener.java
@@ -1,0 +1,55 @@
+package net.sourceforge.vrapper.plugin.sneak.modes;
+
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakState;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakStateManager;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.VrapperEventAdapter;
+import net.sourceforge.vrapper.vim.modes.EditorMode;
+
+public class SneakCommandListener extends VrapperEventAdapter {
+    protected EditorAdaptor editorAdaptor;
+    private SneakStateManager stateManager;
+
+    public SneakCommandListener(EditorAdaptor editorAdaptor, SneakStateManager sneakStateManager) {
+        this.editorAdaptor = editorAdaptor;
+        this.stateManager = sneakStateManager;
+    }
+
+    @Override
+    public void commandAboutToExecute(EditorMode mode) {
+        stateManager.increaseCounters(editorAdaptor);
+    }
+
+    @Override
+    public void commandExecuted(EditorMode mode) {
+    }
+
+    @Override
+    public void stateReset(EditorMode mode, boolean recognized) {
+        // Call this to disable sneak when the user pressed ESC in normal mode
+        verifySneakState();
+    }
+
+    @Override
+    public void modeAboutToSwitch(EditorMode currentMode, EditorMode newMode) {
+    }
+
+    @Override
+    public void modeSwitched(EditorMode oldMode, EditorMode currentMode) {
+    }
+
+    @Override
+    public void vrapperToggled(boolean enabled) {
+        stateManager.markSneakInactive(editorAdaptor);
+    }
+
+    protected void verifySneakState() {
+        SneakState sneakState = stateManager.getSneakState(editorAdaptor);
+
+        if (sneakState.getGlobalEventCounter() != sneakState.getLastSneakCommandEventCounter()) {
+            stateManager.markSneakInactive(editorAdaptor);
+        }
+
+        stateManager.increaseCounters(editorAdaptor);
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/SneakInputMode.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/SneakInputMode.java
@@ -1,0 +1,260 @@
+package net.sourceforge.vrapper.plugin.sneak.modes;
+
+import net.sourceforge.vrapper.keymap.KeyStroke;
+import net.sourceforge.vrapper.keymap.SpecialKey;
+import net.sourceforge.vrapper.keymap.vim.ConstructorWrappers;
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.CommandLineUI;
+import net.sourceforge.vrapper.platform.TextContent;
+import net.sourceforge.vrapper.plugin.sneak.commands.motions.JumpMotionDecorator;
+import net.sourceforge.vrapper.plugin.sneak.commands.motions.SneakMotion;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.EditorAdaptorStateManager;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakState;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.SneakStateManager;
+import net.sourceforge.vrapper.utils.LineInformation;
+import net.sourceforge.vrapper.utils.Search;
+import net.sourceforge.vrapper.utils.StringUtils;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.Options;
+import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.MotionCommand;
+import net.sourceforge.vrapper.vim.commands.VisualMotionCommand;
+import net.sourceforge.vrapper.vim.commands.motions.Motion;
+import net.sourceforge.vrapper.vim.modes.AbstractMode;
+import net.sourceforge.vrapper.vim.modes.AbstractVisualMode;
+import net.sourceforge.vrapper.vim.modes.ExecuteCommandHint;
+import net.sourceforge.vrapper.vim.modes.ModeSwitchHint;
+import net.sourceforge.vrapper.vim.modes.NormalMode;
+import net.sourceforge.vrapper.vim.modes.WithCountHint;
+
+public class SneakInputMode extends AbstractMode {
+    
+    public static final String NAME = SneakInputMode.class.getName();
+    private static final String DISPLAY_NAME = "SNEAK INPUT";
+    public static final ModeSwitchHint SNEAK_BACKWARDS = new ModeSwitchHint() {};
+    public static final ModeSwitchHint FROM_VISUAL = new ModeSwitchHint() {};
+
+    public static final SneakStateManager STATEMANAGER = new EditorAdaptorStateManager();
+
+    protected static final KeyStroke KEY_RETURN = ConstructorWrappers.key(SpecialKey.RETURN);
+    protected static final KeyStroke KEY_ESCAPE = ConstructorWrappers.key(SpecialKey.ESC);
+    protected static final KeyStroke KEY_BACKSP = ConstructorWrappers.key(SpecialKey.BACKSPACE);
+
+    /** Holds the most recent Sneak motion. */
+    public static SneakMotion LAST_SNEAK_MOTION;
+
+    protected CommandLineUI commandLine;
+    protected int sneakInputLength = 2;
+    protected boolean sneakBackwards;
+    protected boolean fromVisual;
+
+    /**
+     * Current sneak sub-mode state. This is kept in this class to make sure it reflects the current
+     * editor as modes are normally created once per EditorAdaptor.
+     */
+    protected SneakState previousState;
+    private int countValue;
+    private int motionCountValue;
+
+    public SneakInputMode(EditorAdaptor editorAdaptor) {
+        super(editorAdaptor);
+        previousState = new SneakState();
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+
+    public SneakState getPreviousState() {
+        return previousState;
+    }
+
+    @Override
+    public boolean handleKey(KeyStroke stroke) {
+        if (stroke.equals(KEY_ESCAPE)) {
+            editorAdaptor.changeModeSafely(editorAdaptor.getLastModeName());
+
+        } else if (stroke.equals(KEY_BACKSP)) {
+            commandLine.erase();
+            if (commandLine.getContents().length() <= 0) {
+                editorAdaptor.changeModeSafely(editorAdaptor.getLastModeName(),
+                        AbstractVisualMode.RECALL_SELECTION_HINT);
+            }
+
+        } else if (stroke.equals(KEY_RETURN)) {
+            if (commandLine.getContents().length() > 0) {
+                startSneaking(commandLine.getContents());
+            } else {
+                // Check if we can reuse an existing SneakMotion stored in the last motion field.
+                // This way we sync the last sneak keyword from a different editor to this one.
+                SneakMotion sneakMotion = LAST_SNEAK_MOTION;
+                if (sneakMotion != null) {
+                    if (sneakMotion.isBackward() != sneakBackwards) {
+                        sneakMotion = sneakMotion.reverse();
+                        saveSneakMotion(sneakMotion);
+                    }
+                    executeMotionInLastMode(sneakMotion, previousState.getSneakSearch().getKeyword());
+                } else if (previousState == null) {
+                    editorAdaptor.changeModeSafely(editorAdaptor.getLastModeName());
+                } else {
+                    startSneaking(previousState.getSneakSearch().getKeyword());
+                }
+            }
+
+        } else if (stroke.getCharacter() == KeyStroke.SPECIAL_KEY) {
+            editorAdaptor.getUserInterfaceService().setErrorMessage("Sneak only accepts printable "
+                    + "characters");
+                editorAdaptor.changeModeSafely(editorAdaptor.getLastModeName(),
+                        AbstractVisualMode.RECALL_SELECTION_HINT);
+
+        } else {
+            commandLine.type(Character.toString(stroke.getCharacter()));
+            if (commandLine.getContents().length() >= sneakInputLength) {
+                startSneaking(commandLine.getContents());
+            }
+        }
+        return true;
+    }
+
+    protected void startSneaking(String searchString) {
+
+        Search searchKeyword = constructSearchKeyword(editorAdaptor, searchString, sneakBackwards);
+
+        SneakMotion sneakMotion = buildSneakMotion(searchKeyword);
+
+        saveSneakMotion(sneakMotion);
+
+        // Clear previous sneak highlights before adding new ones.
+        SneakState previousState = STATEMANAGER.getSneakState(editorAdaptor);
+        if (previousState.isSneaking()) {
+            previousState.deactivateSneak(editorAdaptor.getHighlightingService());
+        }
+
+        // The initial sneak invocation is treated as a jump but following invocations shouldn't.
+        // This decorator lets MotionCommand adjust the jump list and last jump mark.
+        Motion motion = new JumpMotionDecorator(sneakMotion);
+
+        executeMotionInLastMode(motion, searchString);
+    }
+
+    private SneakMotion buildSneakMotion(Search searchKeyword) {
+        int columnLeft = -1;
+        int columnRight = -1;
+
+        //calculate columns
+        if (countValue != Command.NO_COUNT_GIVEN && countValue > 1) {
+            int currentOffset = editorAdaptor.getPosition().getModelOffset();
+            TextContent textContent = editorAdaptor.getModelContent();
+            LineInformation currentLine = textContent.getLineInformationOfOffset(currentOffset);
+            String currentLineContent = textContent.getText(currentLine.getBeginOffset(), currentLine.getLength());
+            int currentOffsetInLine = currentOffset - currentLine.getBeginOffset();
+            Integer tabstop = editorAdaptor.getConfiguration().get(Options.TAB_STOP);
+
+            int[] visualOffsets = StringUtils.calculateVisualOffsets(currentLineContent,
+                    currentLineContent.length(), tabstop);
+            int currentColumn = visualOffsets[currentOffsetInLine];
+            columnLeft = Math.max(0, currentColumn - countValue);
+            columnRight = currentColumn + countValue;
+        }
+        return new SneakMotion(STATEMANAGER, searchKeyword, columnLeft, columnRight);
+    }
+
+    public static Search constructSearchKeyword(EditorAdaptor editorAdaptor, String searchString,
+            boolean sneakBackwards) {
+        // vim-sneak made this configurable, this port assumes we reuse the existing options
+        boolean caseSensitive = ! editorAdaptor.getConfiguration().get(Options.IGNORE_CASE)
+            || (editorAdaptor.getConfiguration().get(Options.SMART_CASE)
+                && StringUtils.containsUppercase(searchString));
+        Search searchKeyword = new Search(searchString, sneakBackwards, caseSensitive);
+        return searchKeyword;
+    }
+
+    protected void executeMotionInLastMode(Motion motion, String searchStringForLogging) {
+        try {
+            MotionCommand motionCommand;
+            if (fromVisual) {
+                motionCommand = new VisualMotionCommand(motion);
+            } else {
+                motionCommand = new MotionCommand(motion);
+            }
+            Command effectiveCommand = motionCommand;
+            if (motionCountValue > 1) {
+                effectiveCommand = motionCommand.withCount(motionCountValue);
+            }
+            editorAdaptor.changeMode(editorAdaptor.getLastModeName(),
+                            AbstractVisualMode.RECALL_SELECTION_HINT,
+                            new ExecuteCommandHint.OnEnter(effectiveCommand));
+        } catch (CommandExecutionException e) {
+            VrapperLog.error("Last mode raised an error when trying to sneak to '"
+                + searchStringForLogging + "'", e);
+            editorAdaptor.changeModeSafely(NormalMode.NAME);
+        } catch (RuntimeException e) {
+            VrapperLog.error("Last mode raised an error when trying to sneak to '"
+                    + searchStringForLogging + "'", e);
+            editorAdaptor.changeModeSafely(NormalMode.NAME);
+        }
+    }
+
+    @Override
+    public void enterMode(ModeSwitchHint... hints)
+            throws CommandExecutionException {
+        super.enterMode(hints);
+
+        // reset defaults
+        sneakInputLength = 2;
+        sneakBackwards = false;
+        fromVisual = false;
+        countValue = 0;
+        motionCountValue = 0;
+
+        for (ModeSwitchHint hint : hints) {
+            if (hint == SNEAK_BACKWARDS) {
+                sneakBackwards = true;
+            } else if (hint == FROM_VISUAL) {
+                fromVisual = true;
+            } else if (hint instanceof WithCountHint) {
+                countValue = ((WithCountHint) hint).getCount();
+            }
+        }
+
+        // If sneak is active, keep it active until the user forcefully quits this mode
+        if (previousState.isSneaking()) {
+            STATEMANAGER.markSneakActive(editorAdaptor);
+        }
+
+        commandLine = editorAdaptor.getCommandLine();
+        commandLine.setPrompt(">");
+        commandLine.open();
+    }
+
+    @Override
+    public void leaveMode(ModeSwitchHint... hints)
+            throws CommandExecutionException {
+        // If sneak is active, keep it active until the user forcefully quits this mode
+        if (previousState.isSneaking()) {
+            STATEMANAGER.markSneakActive(editorAdaptor);
+        }
+
+        super.leaveMode(hints);
+        commandLine.close();
+    }
+
+    /**
+     * Sneak input mode doesn't accept keymaps.
+     */
+    @Override
+    public String resolveKeyMap(KeyStroke stroke) {
+        return null;
+    }
+
+    private void saveSneakMotion(SneakMotion motion) {
+        LAST_SNEAK_MOTION = motion;
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/SneakInputMode.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/modes/SneakInputMode.java
@@ -158,7 +158,6 @@ public class SneakInputMode extends AbstractMode {
     }
 
     protected void startSneaking(String searchString) {
-        // [TODO] Implement sneak column mode search, in which case we need to pass a count value
 
         Search searchKeyword = constructSearchKeyword(editorAdaptor, searchString, sneakBackwards);
 

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakLifecycleListener.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakLifecycleListener.java
@@ -1,0 +1,17 @@
+package net.sourceforge.vrapper.plugin.sneak.provider;
+
+import net.sourceforge.vrapper.platform.PlatformVrapperLifecycleAdapter;
+import net.sourceforge.vrapper.plugin.sneak.commands.utils.EditorAdaptorStateManager;
+import net.sourceforge.vrapper.plugin.sneak.modes.SneakCommandListener;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+public class SneakLifecycleListener extends PlatformVrapperLifecycleAdapter {
+
+    @Override
+    public void editorConfigured(EditorAdaptor editorAdaptor, boolean enabled) {
+        editorAdaptor.addVrapperEventListener(new SneakCommandListener(editorAdaptor,
+                new EditorAdaptorStateManager()));
+
+        // [TODO] Check default bindings
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakModeProvider.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakModeProvider.java
@@ -1,0 +1,22 @@
+package net.sourceforge.vrapper.plugin.sneak.provider;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.vrapper.platform.AbstractPlatformSpecificModeProvider;
+import net.sourceforge.vrapper.plugin.sneak.modes.SneakInputMode;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.modes.EditorMode;
+
+public class SneakModeProvider extends AbstractPlatformSpecificModeProvider {
+
+    public SneakModeProvider() {
+        super(SneakModeProvider.class.getName());
+    }
+
+    @Override
+    public List<EditorMode> getModes(EditorAdaptor editorAdaptor) throws CommandExecutionException {
+        return Collections.<EditorMode>singletonList(new SneakInputMode(editorAdaptor));
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakStateProvider.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakStateProvider.java
@@ -1,0 +1,53 @@
+package net.sourceforge.vrapper.plugin.sneak.provider;
+
+
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.leafBind;
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.state;
+
+import net.sourceforge.vrapper.eclipse.keymap.AbstractEclipseSpecificStateProvider;
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.vim.PlugKeyStroke;
+import net.sourceforge.vrapper.plugin.sneak.modes.ChangeToSneakModeCommand;
+import net.sourceforge.vrapper.vim.commands.Command;
+import net.sourceforge.vrapper.vim.commands.MotionCommand;
+import net.sourceforge.vrapper.vim.commands.VisualMotionCommand;
+import net.sourceforge.vrapper.vim.commands.motions.ContinueFindingMotion;
+
+public class SneakStateProvider extends AbstractEclipseSpecificStateProvider {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected State<Command> normalModeBindings() {
+
+        Command sneakInput = ChangeToSneakModeCommand.withoutHints();
+        Command sneakInputBackwards = ChangeToSneakModeCommand.backwards();
+
+        Command sneakNext = new MotionCommand(ContinueFindingMotion.NORMAL_NAVIGATING);
+        Command sneakPrev = new MotionCommand(ContinueFindingMotion.REVERSE_NAVIGATING);
+
+        return state(
+            leafBind(new PlugKeyStroke("(sneak_s)"), sneakInput),
+            leafBind(new PlugKeyStroke("(sneak_S)"), sneakInputBackwards),
+            leafBind(new PlugKeyStroke("(sneak-next)"), sneakNext),
+            leafBind(new PlugKeyStroke("(sneak-prev)"), sneakPrev)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected State<Command> visualModeBindings() {
+
+        Command sneakInput = ChangeToSneakModeCommand.fromVisual();
+        Command sneakInputBackwards = ChangeToSneakModeCommand.backwardsAndFromVisual();
+
+        Command sneakNext = new VisualMotionCommand(ContinueFindingMotion.NORMAL_NAVIGATING);
+        Command sneakPrev = new VisualMotionCommand(ContinueFindingMotion.REVERSE_NAVIGATING);
+
+        return state(
+            leafBind(new PlugKeyStroke("(sneak_s)"), sneakInput),
+            leafBind(new PlugKeyStroke("(sneak_S)"), sneakInputBackwards),
+            leafBind(new PlugKeyStroke("(sneak-next)"), sneakNext),
+            leafBind(new PlugKeyStroke("(sneak-prev)"), sneakPrev)
+        );
+    }
+}

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakStateProvider.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakStateProvider.java
@@ -8,6 +8,8 @@ import net.sourceforge.vrapper.eclipse.keymap.AbstractEclipseSpecificStateProvid
 import net.sourceforge.vrapper.keymap.State;
 import net.sourceforge.vrapper.keymap.vim.PlugKeyStroke;
 import net.sourceforge.vrapper.plugin.sneak.modes.ChangeToSneakModeCommand;
+import net.sourceforge.vrapper.plugin.sneak.modes.SneakInputMode.CharOffsetHint;
+import net.sourceforge.vrapper.plugin.sneak.modes.SneakInputMode.InputCharsLimitHint;
 import net.sourceforge.vrapper.vim.commands.Command;
 import net.sourceforge.vrapper.vim.commands.MotionCommand;
 import net.sourceforge.vrapper.vim.commands.VisualMotionCommand;
@@ -22,12 +24,22 @@ public class SneakStateProvider extends AbstractEclipseSpecificStateProvider {
         Command sneakInput = ChangeToSneakModeCommand.withoutHints();
         Command sneakInputBackwards = ChangeToSneakModeCommand.backwards();
 
+        Command sneak_f = ChangeToSneakModeCommand.withHints(CharOffsetHint.F_CHARS, InputCharsLimitHint.ONE);
+        Command sneak_F = ChangeToSneakModeCommand.backwards(CharOffsetHint.F_CHARS, InputCharsLimitHint.ONE);
+
+        Command sneak_t = ChangeToSneakModeCommand.withHints(CharOffsetHint.T_CHAR_FORWARD, InputCharsLimitHint.ONE);
+        Command sneak_T = ChangeToSneakModeCommand.backwards(CharOffsetHint.T_CHAR_BACKWARD, InputCharsLimitHint.ONE);
+        
         Command sneakNext = new MotionCommand(ContinueFindingMotion.NORMAL_NAVIGATING);
         Command sneakPrev = new MotionCommand(ContinueFindingMotion.REVERSE_NAVIGATING);
 
         return state(
             leafBind(new PlugKeyStroke("(sneak_s)"), sneakInput),
             leafBind(new PlugKeyStroke("(sneak_S)"), sneakInputBackwards),
+            leafBind(new PlugKeyStroke("(sneak_f)"), sneak_f),
+            leafBind(new PlugKeyStroke("(sneak_F)"), sneak_F),
+            leafBind(new PlugKeyStroke("(sneak_t)"), sneak_t),
+            leafBind(new PlugKeyStroke("(sneak_T)"), sneak_T),
             leafBind(new PlugKeyStroke("(sneak-next)"), sneakNext),
             leafBind(new PlugKeyStroke("(sneak-prev)"), sneakPrev)
         );
@@ -40,12 +52,22 @@ public class SneakStateProvider extends AbstractEclipseSpecificStateProvider {
         Command sneakInput = ChangeToSneakModeCommand.fromVisual();
         Command sneakInputBackwards = ChangeToSneakModeCommand.backwardsAndFromVisual();
 
+        Command sneak_f = ChangeToSneakModeCommand.fromVisual(CharOffsetHint.F_CHARS, InputCharsLimitHint.ONE);
+        Command sneak_F = ChangeToSneakModeCommand.backwardsAndFromVisual(CharOffsetHint.F_CHARS, InputCharsLimitHint.ONE);
+
+        Command sneak_t = ChangeToSneakModeCommand.fromVisual(CharOffsetHint.T_CHAR_FORWARD, InputCharsLimitHint.ONE);
+        Command sneak_T = ChangeToSneakModeCommand.backwardsAndFromVisual(CharOffsetHint.T_CHAR_BACKWARD, InputCharsLimitHint.ONE);
+        
         Command sneakNext = new VisualMotionCommand(ContinueFindingMotion.NORMAL_NAVIGATING);
         Command sneakPrev = new VisualMotionCommand(ContinueFindingMotion.REVERSE_NAVIGATING);
 
         return state(
             leafBind(new PlugKeyStroke("(sneak_s)"), sneakInput),
             leafBind(new PlugKeyStroke("(sneak_S)"), sneakInputBackwards),
+            leafBind(new PlugKeyStroke("(sneak_f)"), sneak_f),
+            leafBind(new PlugKeyStroke("(sneak_F)"), sneak_F),
+            leafBind(new PlugKeyStroke("(sneak_t)"), sneak_t),
+            leafBind(new PlugKeyStroke("(sneak_T)"), sneak_T),
             leafBind(new PlugKeyStroke("(sneak-next)"), sneakNext),
             leafBind(new PlugKeyStroke("(sneak-prev)"), sneakPrev)
         );

--- a/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakTextObjectProvider.java
+++ b/plugins/ports/net.sourceforge.vrapper.plugin.sneak/src/net/sourceforge/vrapper/plugin/sneak/provider/SneakTextObjectProvider.java
@@ -1,0 +1,31 @@
+package net.sourceforge.vrapper.plugin.sneak.provider;
+
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.state;
+import static net.sourceforge.vrapper.keymap.vim.ConstructorWrappers.transitionBind;
+
+import net.sourceforge.vrapper.keymap.State;
+import net.sourceforge.vrapper.keymap.vim.PlugKeyStroke;
+import net.sourceforge.vrapper.platform.AbstractPlatformSpecificTextObjectProvider;
+import net.sourceforge.vrapper.plugin.sneak.keymap.SneakFindCharactersTextObjectState;
+import net.sourceforge.vrapper.vim.commands.TextObject;
+
+public class SneakTextObjectProvider extends AbstractPlatformSpecificTextObjectProvider {
+
+    @Override
+    public String getName() {
+        return SneakTextObjectProvider.class.getName();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public State<TextObject> textObjects() {
+        // [TODO] Implement sneaks of custom length
+        // [TODO] Hook up ; and ,
+        // Currently these will invoke vrapper's default behavior which means the last fX or dfX
+        // motion gets used rather than whatever gets called by (sneak-next)
+        return state(
+                transitionBind(new PlugKeyStroke("(sneak_s)"), SneakFindCharactersTextObjectState.forwards(2)),
+                transitionBind(new PlugKeyStroke("(sneak_S)"), SneakFindCharactersTextObjectState.backwards(2))
+            );
+    }
+}


### PR DESCRIPTION
This has been in progress September 2015 with Mark 1 being implemented in May 2016. I've rewritten it the past few weeks and added to it so that `f`/`F`/`t`/`T` now work as well, giving you a zippy way to navigate your files!

Currently it runs on a cache, doing a search 250 times in a row to find all close occurrences in a single direction. The limit is 500 search items, but it does search for extra items if you use a `count` value before invoking `s`.

To use the plugin, put this in your `.vrapperrc`:

```
nmap s <Plug>(sneak_s)
nmap S <Plug>(sneak_S)

nmap ; <Plug>(sneak-next)
nmap , <Plug>(sneak-prev)

vmap s <Plug>(sneak_s)
vmap Z <Plug>(sneak_S)

vmap ; <Plug>(sneak-next)
vmap , <Plug>(sneak-prev)

nmap f <Plug>(sneak_f)
nmap F <Plug>(sneak_F)
nmap t <Plug>(sneak_t)
nmap T <Plug>(sneak_T)

vmap f <Plug>(sneak_f)
vmap F <Plug>(sneak_F)
vmap t <Plug>(sneak_t)
vmap T <Plug>(sneak_T)

omap z <Plug>(sneak_s)
omap Z <Plug>(sneak_S)
```

I'm still wondering if I can register these mappings by default (at least the `s` and `;` ones) or provide another configuration command.

Suggestions are welcome!