### PR TITLE
Vrapper Eclipse keys

### DIFF
--- a/net.sourceforge.vrapper.eclipse/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vrapper.eclipse/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide,
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.core.resources,
+ org.eclipse.core.expressions,
  net.sourceforge.vrapper.core;bundle-version="0.75.20190321";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: net.sourceforge.vrapper.eclipse.commands;

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -166,5 +166,85 @@
          <variable name="net.sourceforge.vrapper.source.status" priorityLevel="activeSite"/>
       </sourceProvider>
    </extension>
+
+   <!-- Re-usable activation expressions. -->
+   <extension point="org.eclipse.core.expressions.definitions">
+       <!-- Evaluates to true when Vrapper is active, a Vrapper instance is focused and command line is open. -->
+       <definition id="net.sourceforge.vrapper.expr.commandlinemode">
+            <and>
+               <!-- Check that we're even on an editor -->
+               <with variable="activePart">
+                   <instanceof value="org.eclipse.ui.IEditorPart" />
+               </with>
+               <!-- Technically redundant as mode of disabled vrapper would be 'insert mode' -->
+               <with variable="net.sourceforge.vrapper.source.enabled">
+                  <equals value="true"/>
+               </with>
+               <with variable="net.sourceforge.vrapper.source.currentmode">
+                  <equals value="command mode"/>
+               </with>
+               <!-- XXX Only here to increase Vrapper's priority score. -->
+               <with variable="selection">
+                   <iterate ifEmpty="true" operator="or">
+                       <instanceof value="java.lang.Object" />
+                   </iterate>
+               </with>
+            </and>
+       </definition>
+   </extension>
+
+   <!-- Override default HOME / END / Ctrl + Arrow / Past / ... commands in command line. -->
+   <extension
+       point="org.eclipse.ui.handlers">
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.text.goto.lineStart">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.text.goto.lineEnd">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.text.goto.wordNext">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.text.goto.wordPrevious">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.cut">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.copy">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.paste">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+   </extension>
 </plugin>
 

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -285,7 +285,7 @@
            </activeWhen>
        </handler>
 
-       <!-- Override default HOME / END / Ctrl + Arrow / Past / ... commands in command line. -->
+       <!-- Override default HOME / END / Ctrl + Arrow / Paste / ... commands in command line. -->
        <handler
            class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
            commandId="org.eclipse.ui.edit.text.goto.lineStart">
@@ -331,6 +331,13 @@
        <handler
            class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
            commandId="org.eclipse.ui.edit.paste">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
+           </activeWhen>
+       </handler>
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
+           commandId="org.eclipse.ui.edit.selectAll">
            <activeWhen>
                <reference definitionId="net.sourceforge.vrapper.expr.commandlinemode"/>
            </activeWhen>

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -33,6 +33,30 @@
           id="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut"
           name="Send to Vrapper"/>
 
+    <command
+          categoryId="net.sourceforge.vrapper.eclipse.commands"
+          description="Translates a given key into a press of the Up arrow"
+          id="net.sourceforge.vrapper.eclipse.commands.arrowMap.up"
+          name="Vrapper Up Arrow Map"/>
+
+    <command
+          categoryId="net.sourceforge.vrapper.eclipse.commands"
+          description="Translates a given key into a press of the Down arrow"
+          id="net.sourceforge.vrapper.eclipse.commands.arrowMap.down"
+          name="Vrapper Down Arrow Map"/>
+
+    <command
+          categoryId="net.sourceforge.vrapper.eclipse.commands"
+          description="Translates a given key into a press of the Left arrow"
+          id="net.sourceforge.vrapper.eclipse.commands.arrowMap.left"
+          name="Vrapper Left Arrow Map"/>
+
+    <command
+          categoryId="net.sourceforge.vrapper.eclipse.commands"
+          description="Translates a given key into a press of the Right arrow"
+          id="net.sourceforge.vrapper.eclipse.commands.arrowMap.right"
+          name="Vrapper Right Arrow Map"/>
+
    </extension>
 
 
@@ -171,7 +195,14 @@
 
    <!-- Re-usable activation expressions. -->
    <extension point="org.eclipse.core.expressions.definitions">
-       <!-- Evaluates to true when Vrapper is active and a Vrapper instance is focused -->
+       <!-- Evaluates to true when Vrapper is enabled -->
+       <definition id="net.sourceforge.vrapper.expr.enabled">
+           <!-- Check that Vrapper is enabled -->
+           <with variable="net.sourceforge.vrapper.source.enabled">
+              <equals value="true"/>
+           </with>
+       </definition>
+       <!-- Evaluates to true when Vrapper is enabled and a Vrapper instance is focused -->
        <definition id="net.sourceforge.vrapper.expr.activeanymode">
             <and>
                <!-- Check that we're even on an editor -->
@@ -190,7 +221,7 @@
                </not>
             </and>
        </definition>
-       <!-- Evaluates to true when Vrapper is active, a Vrapper instance is focused and command line is open. -->
+       <!-- Evaluates to true when Vrapper is enabled, a Vrapper instance is focused and command line is open. -->
        <definition id="net.sourceforge.vrapper.expr.commandlinemode">
             <and>
                <!-- Check that we're even on an editor -->
@@ -221,6 +252,36 @@
            commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut">
            <activeWhen>
                <reference definitionId="net.sourceforge.vrapper.expr.activeanymode"/>
+           </activeWhen>
+       </handler>
+
+       <!-- Remaps H/J/K/L (or whatever is bound) to Left/Down/Up/Right keypresses which views understand. -->
+       <handler
+             class="net.sourceforge.vrapper.eclipse.actions.VrapperArrowMapHandler"
+             commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.up">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.enabled"/>
+           </activeWhen>
+       </handler>
+       <handler
+             class="net.sourceforge.vrapper.eclipse.actions.VrapperArrowMapHandler"
+             commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.down">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.enabled"/>
+           </activeWhen>
+       </handler>
+       <handler
+             class="net.sourceforge.vrapper.eclipse.actions.VrapperArrowMapHandler"
+             commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.left">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.enabled"/>
+           </activeWhen>
+       </handler>
+       <handler
+             class="net.sourceforge.vrapper.eclipse.actions.VrapperArrowMapHandler"
+             commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.right">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.enabled"/>
            </activeWhen>
        </handler>
 
@@ -311,6 +372,12 @@
       </context>
 
       <!-- Vrapper contexts proper -->
+      <context
+            description="Shortcuts are used when Vrapper is enabled but not focused (e.g. on a view)"
+            id="net.sourceforge.vrapper.eclipse.enabledOnView"
+            name="Vrapper Enabled on a View"
+            parentId="net.sourceforge.vrapper.eclipse.dummy5">
+      </context>
       <context
             description="Shortcuts are used when Vrapper is focused and enabled"
             id="net.sourceforge.vrapper.eclipse.active"

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -6,7 +6,7 @@
    <extension-point id="net.sourceforge.vrapper.eclipse.psmp" name="Platform Specific Mode Provider" schema="schema/net.sourceforge.vrapper.eclipse.psmp.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.pstop" name="Platform Specific TextObject provider" schema="schema/net.sourceforge.vrapper.eclipse.pstop.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.lifecyclelistener" name="Vrapper Lifecycle Listener" schema="schema/net.sourceforge.vrapper.eclipse.lifecyclelistener.exsd"/>
-  <extension
+   <extension
        point="org.eclipse.ui.commands">
     <category
           description="Commands for Vrapper"
@@ -18,10 +18,16 @@
           defaultHandler="net.sourceforge.vrapper.eclipse.actions.VrapperToggleHandler"
           description="Toggles Vrapper"
           id="net.sourceforge.vrapper.eclipse.commands.toggle"
-          name="Toggle Vrapper">
+          name="Toggle Vrapper"/>
 
-    </command>
-    </extension>
+    <command
+          categoryId="net.sourceforge.vrapper.eclipse.commands"
+          defaultHandler="net.sourceforge.vrapper.eclipse.actions.ActivateEditorAndTypeHandler"
+          description="Activates the editor, focuses it and sends the bound key to it (handler is active also if Vrapper is disabled)"
+          id="net.sourceforge.vrapper.eclipse.commands.activateEditorAndType"
+          name="Activate Editor and Type"/>
+
+   </extension>
 
 
     <extension

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -6,13 +6,13 @@
    <extension-point id="net.sourceforge.vrapper.eclipse.psmp" name="Platform Specific Mode Provider" schema="schema/net.sourceforge.vrapper.eclipse.psmp.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.pstop" name="Platform Specific TextObject provider" schema="schema/net.sourceforge.vrapper.eclipse.pstop.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.lifecyclelistener" name="Vrapper Lifecycle Listener" schema="schema/net.sourceforge.vrapper.eclipse.lifecyclelistener.exsd"/>
-   <extension
-       point="org.eclipse.ui.commands">
+
+   <extension point="org.eclipse.ui.commands">
     <category
           description="Commands for Vrapper"
           id="net.sourceforge.vrapper.eclipse.commands"
-          name="Vrapper">
-    </category>
+          name="Vrapper"/>
+
     <command
           categoryId="net.sourceforge.vrapper.eclipse.commands"
           defaultHandler="net.sourceforge.vrapper.eclipse.actions.VrapperToggleHandler"
@@ -23,17 +23,21 @@
     <command
           categoryId="net.sourceforge.vrapper.eclipse.commands"
           defaultHandler="net.sourceforge.vrapper.eclipse.actions.ActivateEditorAndTypeHandler"
-          description="Activates the editor, focuses it and sends the bound key to it (handler is active also if Vrapper is disabled)"
+          description="Activates the editor, focuses it and sends the bound key to it (handler is active even if Vrapper is disabled)"
           id="net.sourceforge.vrapper.eclipse.commands.activateEditorAndType"
           name="Activate Editor and Type"/>
+
+    <command
+          categoryId="net.sourceforge.vrapper.eclipse.commands"
+          description="Sends the bound key directly to Vrapper when Vrapper is focused and active"
+          id="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut"
+          name="Send to Vrapper"/>
 
    </extension>
 
 
-    <extension
-         point="org.eclipse.ui.menus">
-      <menuContribution
-            locationURI="menu:edit?after=additions">
+    <extension point="org.eclipse.ui.menus">
+      <menuContribution locationURI="menu:edit?after=additions">
          <command
                commandId="net.sourceforge.vrapper.eclipse.commands.toggle"
                icon="icons/icon.png"
@@ -41,10 +45,8 @@
                style="toggle">
          </command>
       </menuContribution>
-       <menuContribution
-            locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
-         <toolbar
-               id="net.sourceforge.vrapper.Vrapper">
+       <menuContribution locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
+         <toolbar id="net.sourceforge.vrapper.Vrapper">
             <command
                   commandId="net.sourceforge.vrapper.eclipse.commands.toggle"
                   icon="icons/icon.png"
@@ -56,8 +58,8 @@
             </separator>
          </toolbar>
       </menuContribution>
-
     </extension>
+
     <extension point="org.eclipse.ui.startup">
 		<startup class="net.sourceforge.vrapper.eclipse.activator.VrapperStartup"/>
 	</extension>
@@ -169,6 +171,25 @@
 
    <!-- Re-usable activation expressions. -->
    <extension point="org.eclipse.core.expressions.definitions">
+       <!-- Evaluates to true when Vrapper is active and a Vrapper instance is focused -->
+       <definition id="net.sourceforge.vrapper.expr.activeanymode">
+            <and>
+               <!-- Check that we're even on an editor -->
+               <with variable="activePart">
+                   <instanceof value="org.eclipse.ui.IEditorPart" />
+               </with>
+               <!-- Check that Vrapper is enabled -->
+               <with variable="net.sourceforge.vrapper.source.enabled">
+                  <equals value="true"/>
+               </with>
+               <!-- Check that current mode is not the unknown mode (happens when non-Vrapper editor is open) -->
+               <not>
+                  <with variable="net.sourceforge.vrapper.source.currentmode">
+                     <equals value="(unknown mode)"/>
+                  </with>
+               </not>
+            </and>
+       </definition>
        <!-- Evaluates to true when Vrapper is active, a Vrapper instance is focused and command line is open. -->
        <definition id="net.sourceforge.vrapper.expr.commandlinemode">
             <and>
@@ -193,9 +214,17 @@
        </definition>
    </extension>
 
-   <!-- Override default HOME / END / Ctrl + Arrow / Past / ... commands in command line. -->
-   <extension
-       point="org.eclipse.ui.handlers">
+   <extension point="org.eclipse.ui.handlers">
+       <!-- Our own key handler which only fires when a Vrapper-specific command is bound. -->
+       <handler
+           class="net.sourceforge.vrapper.eclipse.actions.VrapperShortcutHandler"
+           commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut">
+           <activeWhen>
+               <reference definitionId="net.sourceforge.vrapper.expr.activeanymode"/>
+           </activeWhen>
+       </handler>
+
+       <!-- Override default HOME / END / Ctrl + Arrow / Past / ... commands in command line. -->
        <handler
            class="net.sourceforge.vrapper.eclipse.actions.VrapperCommandLineMotionHandler"
            commandId="org.eclipse.ui.edit.text.goto.lineStart">
@@ -280,6 +309,7 @@
             name="ZZ Vrapper's Dummy Contexts"
             parentId="net.sourceforge.vrapper.eclipse.dummy4">
       </context>
+
       <!-- Vrapper contexts proper -->
       <context
             description="Shortcuts are used when Vrapper is focused and enabled"

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -246,5 +246,71 @@
            </activeWhen>
        </handler>
    </extension>
+
+   <extension
+         point="org.eclipse.ui.contexts">
+      <!-- XXX These only exist to boost Vrapper's importance but are never activated. -->
+      <context
+            description="Dummy context for Vrapper"
+            id="net.sourceforge.vrapper.eclipse.dummy1"
+            name="ZZ Vrapper's Dummy Contexts"
+            parentId="org.eclipse.ui.textEditorScope">
+      </context>
+      <context
+            description="Dummy context for Vrapper"
+            id="net.sourceforge.vrapper.eclipse.dummy2"
+            name="ZZ Vrapper's Dummy Contexts"
+            parentId="net.sourceforge.vrapper.eclipse.dummy1">
+      </context>
+      <context
+            description="Dummy context for Vrapper"
+            id="net.sourceforge.vrapper.eclipse.dummy3"
+            name="ZZ Vrapper's Dummy Contexts"
+            parentId="net.sourceforge.vrapper.eclipse.dummy2">
+      </context>
+      <context
+            description="Dummy context for Vrapper"
+            id="net.sourceforge.vrapper.eclipse.dummy4"
+            name="ZZ Vrapper's Dummy Contexts"
+            parentId="net.sourceforge.vrapper.eclipse.dummy3">
+      </context>
+      <context
+            description="Dummy context for Vrapper"
+            id="net.sourceforge.vrapper.eclipse.dummy5"
+            name="ZZ Vrapper's Dummy Contexts"
+            parentId="net.sourceforge.vrapper.eclipse.dummy4">
+      </context>
+      <!-- Vrapper contexts proper -->
+      <context
+            description="Shortcuts are used when Vrapper is focused and enabled"
+            id="net.sourceforge.vrapper.eclipse.active"
+            name="Vrapper Active"
+            parentId="net.sourceforge.vrapper.eclipse.dummy5">
+      </context>
+      <context
+            description="Shortcuts are used when Vrapper is focused and in normal mode"
+            id="net.sourceforge.vrapper.eclipse.active.normal"
+            name="Vrapper Normal mode Active"
+            parentId="net.sourceforge.vrapper.eclipse.active">
+      </context>
+      <context
+            description="Shortcuts are used when Vrapper is focused and in commandline or search mode"
+            id="net.sourceforge.vrapper.eclipse.active.command"
+            name="Vrapper Commandline Opened"
+            parentId="net.sourceforge.vrapper.eclipse.active">
+      </context>
+      <context
+            description="Shortcuts are used when Vrapper is focused and in visual or select mode"
+            id="net.sourceforge.vrapper.eclipse.active.visual"
+            name="Vrapper Visual mode Active"
+            parentId="net.sourceforge.vrapper.eclipse.active">
+      </context>
+      <context
+            description="Shortcuts are used when Vrapper is focused and in insert mode"
+            id="net.sourceforge.vrapper.eclipse.active.insert"
+            name="Vrapper Insert mode Active"
+            parentId="net.sourceforge.vrapper.eclipse.active">
+      </context>
+   </extension>
 </plugin>
 

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -88,24 +88,6 @@
 		<startup class="net.sourceforge.vrapper.eclipse.activator.VrapperStartup"/>
 	</extension>
 
-
-   <extension point="org.eclipse.ui.bindings">
-      <key
-            sequence="ESC CTRL+C"
-            contextId="org.eclipse.jdt.ui.javaEditorScope"
-            commandId=""
-            schemeId="kg.totality.core.insert_mode"/>
-      <key
-            sequence="ESC CTRL+F"
-            contextId="org.eclipse.jdt.ui.javaEditorScope"
-            commandId=""
-            schemeId="kg.totality.core.insert_mode"/>
-	  <scheme
-          description="Vim&apos;s insert mode emulation"
-          id="kg.totality.core.insert_mode"
-          name="Vim&apos;s key bindings"
-          parentId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
-     </extension>
    <extension
          point="net.sourceforge.vrapper.eclipse.pssp">
       <keymap-provider
@@ -416,5 +398,78 @@
             parentId="net.sourceforge.vrapper.eclipse.active">
       </context>
    </extension>
+
+   <extension point="org.eclipse.ui.bindings">
+
+      <!-- Bind sample shortcuts in default scheme so user can use the pre-set context. -->
+      <key sequence="F15 F4" commandId="net.sourceforge.vrapper.eclipse.commands.toggle" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+      <key sequence="F15 ESC" commandId="net.sourceforge.vrapper.eclipse.commands.activateEditorAndType" contextId="org.eclipse.ui.contexts.window" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+      <key sequence="F15 CTRL+A" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+      <key sequence="F15 K" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.up" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+      <key sequence="F15 J" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.down" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+      <key sequence="F15 H" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.left" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+      <key sequence="F15 L" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.right" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+
+      <!-- Scheme to binds frequent key combinations to Vrapper input. -->
+      <scheme
+          description="Binds all keys to Vrapper (when enabled)"
+          id="net.sourceforge.vrapper.keyscheme"
+          name="Vim&apos;s key bindings"
+          parentId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+
+      <key sequence="ESC" commandId="net.sourceforge.vrapper.eclipse.commands.activateEditorAndType" contextId="org.eclipse.ui.contexts.window" schemeId="net.sourceforge.vrapper.keyscheme"/>
+
+      <key sequence="J" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.up" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="K" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.down" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="H" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.left" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="L" commandId="net.sourceforge.vrapper.eclipse.commands.arrowMap.right" contextId="net.sourceforge.vrapper.eclipse.enabledOnView" schemeId="net.sourceforge.vrapper.keyscheme"/>
+
+	  <!-- These bindings might be removed later once we can listen to the default Eclipse commands associated with them -->
+      <key sequence="HOME" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="END" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+HOME" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+END" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+
+      <key sequence="CTRL+A" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+B" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+C" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+D" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+E" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+F" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+G" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+H" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+I" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+J" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+K" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+L" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+M" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+N" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+O" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+P" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+R" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+Q" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+S" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+T" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+U" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+V" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+W" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+X" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+Y" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+Z" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+
+      <key sequence="CTRL+1" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+2" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+3" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+4" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+5" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+6" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+7" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+8" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+9" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+0" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+-" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+      <key sequence="CTRL+=" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+
+     </extension>
 </plugin>
 

--- a/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -160,5 +160,11 @@
             provider-class="net.sourceforge.vrapper.eclipse.keymap.EclipseTextObjectProvider">
       </textobject-provider>
    </extension>
+
+   <extension point="org.eclipse.ui.services">
+      <sourceProvider provider="net.sourceforge.vrapper.eclipse.activator.VrapperStatusSourceProvider">
+         <variable name="net.sourceforge.vrapper.source.status" priorityLevel="activeSite"/>
+      </sourceProvider>
+   </extension>
 </plugin>
 

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/ActivateEditorAndTypeHandler.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/ActivateEditorAndTypeHandler.java
@@ -1,0 +1,140 @@
+package net.sourceforge.vrapper.eclipse.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.keys.IBindingService;
+
+import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
+import net.sourceforge.vrapper.eclipse.interceptor.UnknownEditorException;
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+
+public class ActivateEditorAndTypeHandler extends AbstractHandler {
+
+    /**
+     * Set to true when a function higher up the call stack is already executing events.
+     * In a true multi-threaded application this should have been a ThreadLocal, but here it's
+     * no issue since Eclipse only allows the singleton UI thread to manipulate widgets.
+     */
+    private static volatile boolean isReentrant;
+    private IBindingService bindingService;
+
+    public ActivateEditorAndTypeHandler() {
+        super();
+        if (bindingService == null) {
+            bindingService = (IBindingService) PlatformUI.getWorkbench().getService(IBindingService.class); 
+        }
+    }
+
+    @Override
+    public void dispose() {
+        bindingService = null;
+    }
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        IWorkbenchWindow window = HandlerUtil.getActiveWorkbenchWindowChecked(event);
+        IWorkbenchPage page = window.getActivePage();
+        if (page != null) {
+            IEditorPart part = HandlerUtil.getActiveEditor(event);
+            if (part != null) {
+                page.activate(part);
+
+                // Now focus editor component inside if we can find a Vrapper instance for it
+                try {
+                    InputInterceptor interceptor = VrapperPlugin.getDefault().findActiveInterceptor(part);
+                    ISourceViewer viewer = interceptor.getPlatform().getUnderlyingSourceViewer();
+
+                    StyledText textWidget = viewer.getTextWidget();
+                    textWidget.setFocus();
+
+                    // Find the key event used to trigger this handler (if any), send to editor
+                    Object trigger = event.getTrigger();
+                    if (trigger != null && trigger instanceof Event
+                            && ((Event)trigger).type == SWT.KeyDown) {
+                        Event clone = cloneEvent((Event)trigger);
+                        clone.widget = textWidget;
+                        clone.doit = true;
+
+                        invokeKeyEventNonReentrant(clone, textWidget);
+                    }
+
+                } catch (IllegalThreadStateException e) {
+                    VrapperLog.info("Handler was being executed reentrant, stopping");
+                } catch (VrapperPlatformException e) {
+                    VrapperLog.error("No editor to focus, encountered platformexception", e);
+                } catch (UnknownEditorException e) {
+                    VrapperLog.debug("No editor to focus on active page");
+                }
+            }
+        }
+        return null; 
+    }
+
+    /**
+     * Sends a KeyDown event back to the text widget after temporarily disabling Eclipse's key
+     * binding to avoid arriving in the current handler again.
+     * Just to be safe we check whether this function is entered twice and in that case bail out
+     * with an exception.
+     */
+    private void invokeKeyEventNonReentrant(Event event, StyledText textWidget) {
+        boolean tempReentrantState = isReentrant;
+        boolean tempKeyFilterState = bindingService.isKeyFilterEnabled();
+        try {
+            if (isReentrant) {
+                throw new IllegalThreadStateException("Event is being handled twice");
+            } else {
+                isReentrant = true;
+                bindingService.setKeyFilterEnabled(false);
+                textWidget.notifyListeners(event.type, event);
+            }
+        } finally {
+            bindingService.setKeyFilterEnabled(tempKeyFilterState);
+            isReentrant = tempReentrantState;
+        }
+    }
+
+    private Event cloneEvent(Event source) {
+        Event clone = new Event();
+        clone.button = source.button;
+        clone.character = source.character;
+        clone.count = source.count;
+        clone.data = source.data;
+        clone.detail = source.detail;
+        clone.display = source.display;
+        clone.doit = source.doit;
+        clone.end = source.end;
+        clone.gc = source.gc;
+        clone.height = source.height;
+        clone.index = source.index;
+        clone.item = source.item;
+        clone.keyCode = source.keyCode;
+        clone.keyLocation = source.keyLocation;
+        clone.start = source.start;
+        clone.stateMask = source.stateMask;
+        clone.text = source.text;
+        clone.time = source.time;
+        clone.type = source.type;
+        clone.widget = source.widget;
+        clone.width = source.width;
+        clone.x = source.x;
+        clone.y = source.y;
+        return clone;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperArrowMapHandler.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperArrowMapHandler.java
@@ -1,0 +1,76 @@
+package net.sourceforge.vrapper.eclipse.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.Widget;
+
+import net.sourceforge.vrapper.log.VrapperLog;
+
+/**
+ * Remaps an kind of key into the press of an Up / Down / Left / Right arrow key.
+ */
+public class VrapperArrowMapHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        String commandId = event.getCommand().getId();
+
+        if ( ! (event.getTrigger() instanceof Event)) {
+            return null;
+        }
+        Event triggerEvent = (Event) event.getTrigger();
+        if (triggerEvent.type != SWT.KeyDown) {
+            VrapperLog.debug("Shortcut handler received an activation other than key type?!?");
+            return null;
+        }
+
+        Widget widget = triggerEvent.widget;
+
+        // Act as if we're in Insert mode if textbox is focused: insert input key in widget
+        if (widget instanceof Text || widget instanceof StyledText) {
+            // Check that this command is bound to a Unicode character (and not F1 or something)
+            if ((triggerEvent.stateMask & SWT.MODIFIER_MASK) == 0
+                    && (triggerEvent.keyCode & SWT.KEYCODE_BIT) == 0) {
+
+                String input = new StringBuilder().appendCodePoint(triggerEvent.keyCode).toString();
+                if (widget instanceof Text) {
+                    Text textBox = (Text) widget;
+                    textBox.insert(input);
+                } else if (widget instanceof StyledText) {
+                    StyledText styledText = (StyledText) widget;
+                    styledText.insert(input);
+                }
+            }
+        } else {
+
+            Event mappedEvent = null;
+            // This handler can accept 4 commands (up/down/left/right) and translates them into arrow key presses
+            if (commandId.endsWith(".up")) {
+                mappedEvent = keyEvent(SWT.ARROW_UP);
+            } else if (commandId.endsWith(".down")) {
+                mappedEvent = keyEvent(SWT.ARROW_DOWN);
+            } else if (commandId.endsWith(".right")) {
+                mappedEvent = keyEvent(SWT.ARROW_RIGHT);
+            } else if (commandId.endsWith(".left")) {
+                mappedEvent = keyEvent(SWT.ARROW_LEFT);
+            }
+            if (mappedEvent != null) {
+                triggerEvent.display.post(mappedEvent);
+            }
+        }
+
+        return null;
+    }
+
+    private static Event keyEvent(int keyCode) {
+        Event result = new Event();
+        result.type = SWT.KeyDown;
+        result.keyCode = keyCode;
+        return result;
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperCommandLineMotionHandler.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperCommandLineMotionHandler.java
@@ -35,22 +35,30 @@ public class VrapperCommandLineMotionHandler extends AbstractHandler {
             EclipseCommandLineUI commandLine = 
                     (EclipseCommandLineUI) interceptor.getEditorAdaptor().getCommandLine();
 
+            // Detect which of the commands bound in plugin.xml was used to trigger this handler:
             if (commandId.endsWith(".lineStart")) {
                 commandLine.setPosition(0);
 
             } else if (commandId.endsWith(".lineEnd")) {
-                int lastPos = commandLine.getEndPosition();
-                commandLine.setPosition(lastPos);
+                commandLine.setPosition(commandLine.getEndPosition());
+
             } else if (commandId.endsWith(".wordNext")) {
                 commandLine.getWidget().invokeAction(ST.WORD_NEXT);
+
             } else if (commandId.endsWith(".wordPrevious")) {
                 commandLine.getWidget().invokeAction(ST.WORD_PREVIOUS);
+
             } else if (commandId.endsWith(".paste")) {
                 commandLine.getWidget().invokeAction(ST.PASTE);
+
             } else if (commandId.endsWith(".cut")) {
                 commandLine.getWidget().invokeAction(ST.CUT);
+
             } else if (commandId.endsWith(".copy")) {
                 commandLine.getWidget().invokeAction(ST.COPY);
+
+            } else if (commandId.endsWith(".selectAll")) {
+                commandLine.setSelection(0, commandLine.getEndPosition());
             }
             // Make sure caret remains after prompt characters
             commandLine.clipSelection();

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperCommandLineMotionHandler.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperCommandLineMotionHandler.java
@@ -1,0 +1,64 @@
+package net.sourceforge.vrapper.eclipse.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.swt.custom.ST;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptorManager;
+import net.sourceforge.vrapper.eclipse.interceptor.UnknownEditorException;
+import net.sourceforge.vrapper.eclipse.ui.EclipseCommandLineUI;
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+import net.sourceforge.vrapper.vim.modes.commandline.AbstractCommandLineMode;
+
+/**
+ * Handles Home / End / Page up / Page down motions.
+ */
+public class VrapperCommandLineMotionHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        String commandId = event.getCommand().getId();
+        // Guaranteed to be present through core expression in plugin.xml
+        IEditorPart activeEditor = HandlerUtil.getActiveEditor(event);
+        try {
+            InputInterceptor interceptor = InputInterceptorManager.INSTANCE.findActiveInterceptor(activeEditor);
+
+            if ( ! (interceptor.getEditorAdaptor().getCurrentMode() instanceof AbstractCommandLineMode)) {
+                VrapperLog.info("Command line is not shown, ignoring keypress");
+                return null;
+            }
+            EclipseCommandLineUI commandLine = 
+                    (EclipseCommandLineUI) interceptor.getEditorAdaptor().getCommandLine();
+
+            if (commandId.endsWith(".lineStart")) {
+                commandLine.setPosition(0);
+
+            } else if (commandId.endsWith(".lineEnd")) {
+                int lastPos = commandLine.getEndPosition();
+                commandLine.setPosition(lastPos);
+            } else if (commandId.endsWith(".wordNext")) {
+                commandLine.getWidget().invokeAction(ST.WORD_NEXT);
+            } else if (commandId.endsWith(".wordPrevious")) {
+                commandLine.getWidget().invokeAction(ST.WORD_PREVIOUS);
+            } else if (commandId.endsWith(".paste")) {
+                commandLine.getWidget().invokeAction(ST.PASTE);
+            } else if (commandId.endsWith(".cut")) {
+                commandLine.getWidget().invokeAction(ST.CUT);
+            } else if (commandId.endsWith(".copy")) {
+                commandLine.getWidget().invokeAction(ST.COPY);
+            }
+            // Make sure caret remains after prompt characters
+            commandLine.clipSelection();
+        } catch (VrapperPlatformException e) {
+            VrapperLog.error("Failed to find editor for part " + activeEditor, e);
+        } catch (UnknownEditorException e) {
+            VrapperLog.error("Could not find interceptor for part " + activeEditor, e);
+        }
+        return null;
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperShortcutHandler.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperShortcutHandler.java
@@ -1,0 +1,47 @@
+package net.sourceforge.vrapper.eclipse.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.VerifyEvent;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptorManager;
+import net.sourceforge.vrapper.eclipse.interceptor.UnknownEditorException;
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+
+
+public class VrapperShortcutHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        if ( ! (event.getTrigger() instanceof Event)) {
+            return null;
+        }
+        Event triggerEvent = (Event) event.getTrigger();
+        if (triggerEvent.type != SWT.KeyDown) {
+            return null;
+        }
+        VerifyEvent verifyEvent = new VerifyEvent(triggerEvent);
+
+        // Guaranteed to be present through core expression in plugin.xml
+        IEditorPart activeEditor = HandlerUtil.getActiveEditor(event);
+        try {
+            InputInterceptor interceptor = InputInterceptorManager.INSTANCE.findActiveInterceptor(activeEditor);
+            if (interceptor == null) {
+                VrapperLog.error("Could not find interceptor for part " + activeEditor);
+            }
+            interceptor.verifyKey(verifyEvent);
+        } catch (VrapperPlatformException e) {
+            VrapperLog.error("Failed to find editor for part " + activeEditor, e);
+        } catch (UnknownEditorException e) {
+            VrapperLog.error("Could not find interceptor for part " + activeEditor, e);
+        }
+        return null;
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperToggleHandler.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperToggleHandler.java
@@ -3,13 +3,16 @@ package net.sourceforge.vrapper.eclipse.actions;
 import java.util.Map;
 
 import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
+import net.sourceforge.vrapper.eclipse.activator.VrapperStatusSourceProvider;
 
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.commands.IElementUpdater;
 import org.eclipse.ui.menus.UIElement;
+import org.eclipse.ui.services.ISourceProviderService;
 
 /**
  * The action which is available in the menu and toolbar to activate the
@@ -21,12 +24,20 @@ public class VrapperToggleHandler extends AbstractHandler implements IElementUpd
      * accordingly.
      */
     public Object execute(ExecutionEvent event) {
-        if (!VrapperPlugin.isVrapperEnabled())
-            VrapperPlugin.setVrapperEnabled(true);
-        else
-            VrapperPlugin.setVrapperEnabled(false);
 
-        ICommandService service = (ICommandService) PlatformUI.getWorkbench().getService(ICommandService.class);
+        boolean targetEnabledFlag = !VrapperPlugin.isVrapperEnabled();
+        VrapperPlugin.setVrapperEnabled(targetEnabledFlag);
+
+        IWorkbench workbench = PlatformUI.getWorkbench();
+
+        // Fire listeners on source provider so they know the enabled status was changed
+        ISourceProviderService sourceProviderService =
+                (ISourceProviderService) workbench.getService(ISourceProviderService.class);
+        VrapperStatusSourceProvider sourceProvider = (VrapperStatusSourceProvider)
+                sourceProviderService.getSourceProvider(VrapperStatusSourceProvider.SOURCE_ENABLED);
+        sourceProvider.fireVrapperEnabledChange(targetEnabledFlag);
+
+        ICommandService service = (ICommandService) workbench.getService(ICommandService.class);
         service.refreshElements(event.getCommand().getId(), null);
         return null;
     }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperToggleHandler.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/actions/VrapperToggleHandler.java
@@ -15,8 +15,7 @@ import org.eclipse.ui.menus.UIElement;
  * The action which is available in the menu and toolbar to activate the
  * vim-like behaviour on newly created editors.
  */
-public class VrapperToggleHandler extends AbstractHandler implements
-        IElementUpdater {
+public class VrapperToggleHandler extends AbstractHandler implements IElementUpdater {
     /**
      * adds / removes the listener and sets the actions "checked" status
      * accordingly.

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -17,6 +17,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.ISources;
+import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWindowListener;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchListener;
@@ -179,12 +180,32 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
 
     void activateVrapperShortcutContexts() {
         final IContextService contextService = (IContextService) getWorkbench().getService(IContextService.class);
-        
+
+        contextService.activateContext("net.sourceforge.vrapper.eclipse.enabledOnView", vrapperEnabledOnViewExpression(), true);
+
         contextService.activateContext("net.sourceforge.vrapper.eclipse.active", vrapperEnabledInAnyModeExpression(), true);
         contextService.activateContext("net.sourceforge.vrapper.eclipse.active.normal", vrapperEnabledInModeExpression(NormalMode.NAME), true);
         contextService.activateContext("net.sourceforge.vrapper.eclipse.active.command", vrapperEnabledInModeExpression(CommandLineMode.NAME), true);
         contextService.activateContext("net.sourceforge.vrapper.eclipse.active.visual", vrapperEnabledInModeExpression(VisualMode.NAME), true);
         contextService.activateContext("net.sourceforge.vrapper.eclipse.active.insert", vrapperEnabledInModeExpression(InsertMode.NAME), true);
+    }
+
+    private static Expression vrapperEnabledOnViewExpression() {
+        return new Expression() {
+            @Override
+            public EvaluationResult evaluate(IEvaluationContext context) throws CoreException {
+                Object currentlyActivePart = context.getVariable(ISources.ACTIVE_PART_NAME);
+                boolean onAView = currentlyActivePart instanceof IViewPart;
+                boolean vrapperEnabled = (Boolean) context.getVariable(VrapperStatusSourceProvider.SOURCE_ENABLED);
+                return EvaluationResult.valueOf(vrapperEnabled && onAView);
+            }
+
+            @Override
+            public void collectExpressionInfo(ExpressionInfo info) {
+                info.addVariableNameAccess(ISources.ACTIVE_PART_NAME);
+                info.addVariableNameAccess(VrapperStatusSourceProvider.SOURCE_ENABLED);
+            }
+        };
     }
 
     private static Expression vrapperEnabledInAnyModeExpression() {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -79,6 +79,13 @@ public class VrapperPlugin extends AbstractUIPlugin implements IStartup, Log {
         return InputInterceptorManager.INSTANCE.findActiveInterceptor(activeEditor);
     }
 
+    /**
+     * Returns the currently active Vrapper instance (InputInterceptor) for the given editor.
+     * @param toplevelEditor IEditorPart to look for.
+     * @return an InputInterceptor instance.
+     * @throws VrapperPlatformException if Vrapper triggered errors while querying toplevelEditor.
+     * @throws UnknownEditorException when this part did not have a corresponding Vrapper instance.
+     */
     public InputInterceptor findActiveInterceptor(IEditorPart toplevelEditor)
             throws VrapperPlatformException, UnknownEditorException {
         return InputInterceptorManager.INSTANCE.findActiveInterceptor(toplevelEditor);

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -1,13 +1,10 @@
 package net.sourceforge.vrapper.eclipse.activator;
 
-import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
-import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptorManager;
-import net.sourceforge.vrapper.eclipse.interceptor.UnknownEditorException;
-import net.sourceforge.vrapper.log.Log;
-import net.sourceforge.vrapper.log.VrapperLog;
-import net.sourceforge.vrapper.platform.VrapperPlatformException;
-import net.sourceforge.vrapper.vim.EditorAdaptor;
-
+import org.eclipse.core.expressions.EvaluationResult;
+import org.eclipse.core.expressions.Expression;
+import org.eclipse.core.expressions.ExpressionInfo;
+import org.eclipse.core.expressions.IEvaluationContext;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -19,7 +16,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
-import org.eclipse.ui.IStartup;
+import org.eclipse.ui.ISources;
 import org.eclipse.ui.IWindowListener;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchListener;
@@ -27,15 +24,28 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.prefs.BackingStoreException;
 
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptorManager;
+import net.sourceforge.vrapper.eclipse.interceptor.UnknownEditorException;
+import net.sourceforge.vrapper.log.Log;
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.modes.InsertMode;
+import net.sourceforge.vrapper.vim.modes.NormalMode;
+import net.sourceforge.vrapper.vim.modes.VisualMode;
+import net.sourceforge.vrapper.vim.modes.commandline.CommandLineMode;
+
 /**
  * The activator class controls the plug-in life cycle
  */
-public class VrapperPlugin extends AbstractUIPlugin implements IStartup, Log {
+public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log {
 
     // The plug-in ID
     public static final String PLUGIN_ID = "net.sourceforge.vrapper.eclipse";
@@ -98,8 +108,8 @@ public class VrapperPlugin extends AbstractUIPlugin implements IStartup, Log {
         VrapperLog.setImplementation(this);
     }
 
-    public void earlyStartup() {
-    }
+//    public void earlyStartup() {
+//    }
 
     @Override
     public void stop(BundleContext context) throws Exception {
@@ -165,6 +175,60 @@ public class VrapperPlugin extends AbstractUIPlugin implements IStartup, Log {
                 return true;
             }
         });
+    }
+
+    void activateVrapperShortcutContexts() {
+        final IContextService contextService = (IContextService) getWorkbench().getService(IContextService.class);
+        
+        contextService.activateContext("net.sourceforge.vrapper.eclipse.active", vrapperEnabledInAnyModeExpression(), true);
+        contextService.activateContext("net.sourceforge.vrapper.eclipse.active.normal", vrapperEnabledInModeExpression(NormalMode.NAME), true);
+        contextService.activateContext("net.sourceforge.vrapper.eclipse.active.command", vrapperEnabledInModeExpression(CommandLineMode.NAME), true);
+        contextService.activateContext("net.sourceforge.vrapper.eclipse.active.visual", vrapperEnabledInModeExpression(VisualMode.NAME), true);
+        contextService.activateContext("net.sourceforge.vrapper.eclipse.active.insert", vrapperEnabledInModeExpression(InsertMode.NAME), true);
+    }
+
+    private static Expression vrapperEnabledInAnyModeExpression() {
+        return new Expression() {
+            @Override
+            public EvaluationResult evaluate(IEvaluationContext context) throws CoreException {
+                Object currentlyActivePart = context.getVariable(ISources.ACTIVE_PART_NAME);
+                if ( ! (currentlyActivePart instanceof IEditorPart)) {
+                    return EvaluationResult.FALSE;
+                }
+                Boolean vrapperEnabled = (Boolean) context.getVariable(VrapperStatusSourceProvider.SOURCE_ENABLED);
+                String vrapperMode = (String) context.getVariable(VrapperStatusSourceProvider.SOURCE_CURRENTMODE);
+                return EvaluationResult.valueOf(vrapperEnabled && ! VrapperStatusSourceProvider.MODE_UNKNOWN.equals(vrapperMode));
+            }
+
+            @Override
+            public void collectExpressionInfo(ExpressionInfo info) {
+                info.addVariableNameAccess(ISources.ACTIVE_PART_NAME);
+                info.addVariableNameAccess(VrapperStatusSourceProvider.SOURCE_CURRENTMODE);
+                info.addVariableNameAccess(VrapperStatusSourceProvider.SOURCE_ENABLED);
+            }
+        };
+    }
+
+    private static Expression vrapperEnabledInModeExpression(final String expectedModeName) {
+        return new Expression() {
+            @Override
+            public EvaluationResult evaluate(IEvaluationContext context) throws CoreException {
+                Object currentlyActivePart = context.getVariable(ISources.ACTIVE_PART_NAME);
+                if ( ! (currentlyActivePart instanceof IEditorPart)) {
+                    return EvaluationResult.FALSE;
+                }
+                Boolean vrapperEnabled = (Boolean) context.getVariable(VrapperStatusSourceProvider.SOURCE_ENABLED);
+                String vrapperMode = (String) context.getVariable(VrapperStatusSourceProvider.SOURCE_CURRENTMODE);
+                return EvaluationResult.valueOf(vrapperEnabled && expectedModeName.equals(vrapperMode));
+            }
+
+            @Override
+            public void collectExpressionInfo(ExpressionInfo info) {
+                info.addVariableNameAccess(ISources.ACTIVE_PART_NAME);
+                info.addVariableNameAccess(VrapperStatusSourceProvider.SOURCE_CURRENTMODE);
+                info.addVariableNameAccess(VrapperStatusSourceProvider.SOURCE_ENABLED);
+            }
+        };
     }
 
     private static void storeVimEmulationOfActiveEditors() throws BackingStoreException {

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperStartup.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperStartup.java
@@ -13,6 +13,7 @@ public class VrapperStartup implements IStartup {
                 plugin.restoreVimEmulationInActiveEditors();
                 plugin.addEditorListeners();
                 plugin.addShutdownListener();
+                plugin.activateVrapperShortcutContexts();
                 plugin.toggleVrapper();
             }
         });

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperStatusSourceProvider.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperStatusSourceProvider.java
@@ -1,0 +1,71 @@
+package net.sourceforge.vrapper.eclipse.activator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.ui.AbstractSourceProvider;
+import org.eclipse.ui.ISources;
+
+import net.sourceforge.vrapper.vim.modes.EditorMode;
+import net.sourceforge.vrapper.vim.modes.InsertMode;
+import net.sourceforge.vrapper.vim.modes.NormalMode;
+import net.sourceforge.vrapper.vim.modes.VisualMode;
+import net.sourceforge.vrapper.vim.modes.commandline.AbstractCommandLineMode;
+import net.sourceforge.vrapper.vim.modes.commandline.CommandLineMode;
+
+public class VrapperStatusSourceProvider extends AbstractSourceProvider {
+    /** Source Id for a boolean flag indicating whether Vrapper is enabled. */
+    public static final String SOURCE_ENABLED = "net.sourceforge.vrapper.source.enabled";
+    /** Current mode of the last-activated editor. */
+    public static final String SOURCE_CURRENTMODE = "net.sourceforge.vrapper.source.currentmode";
+
+    /** The current editor does not seem to be a Vrapper instance, hence the current mode is unknown. */
+    public static final String MODE_UNKNOWN = "(unknown mode)";
+
+    private String lastSeenMode = MODE_UNKNOWN;
+
+    public VrapperStatusSourceProvider() {
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes") // Eclipse API uses raw Map...
+    public Map getCurrentState() {
+        Boolean vrapperEnabled = VrapperPlugin.isVrapperEnabled();
+        Map<String, Object> result = new HashMap<String, Object>();
+        result.put(SOURCE_ENABLED, vrapperEnabled);
+        result.put(SOURCE_CURRENTMODE, lastSeenMode);
+        return result;
+    }
+
+    @Override
+    public String[] getProvidedSourceNames() {
+        return new String[] { SOURCE_ENABLED, SOURCE_CURRENTMODE };
+    }
+
+    public void fireVrapperEnabledChange(boolean enabled) {
+        super.fireSourceChanged(ISources.ACTIVE_EDITOR, SOURCE_ENABLED, enabled);
+    }
+
+    public void fireEditorModeChange(EditorMode currentMode) {
+        // When Vrapper is not initialized OR when an editor without Vrapper support is focused
+        if (currentMode == null) {
+            lastSeenMode = MODE_UNKNOWN;
+
+        } else if (currentMode instanceof NormalMode) {
+            lastSeenMode = NormalMode.NAME;
+        } else if (currentMode instanceof VisualMode) {
+            lastSeenMode = VisualMode.NAME;
+        } else if (currentMode instanceof InsertMode) {
+            lastSeenMode = InsertMode.NAME;
+        } else if (currentMode instanceof AbstractCommandLineMode) {
+            lastSeenMode = CommandLineMode.NAME;
+        } else {
+            lastSeenMode = currentMode.getName();
+        }
+        super.fireSourceChanged(ISources.ACTIVE_EDITOR, SOURCE_CURRENTMODE, lastSeenMode);
+    }
+}

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
@@ -58,6 +58,7 @@ public class EclipsePlatform implements Platform {
     private final UnderlyingEditorSettings underlyingEditorSettings;
     private final LocalConfiguration localConfiguration;
     private final AbstractTextEditor underlyingEditor;
+    private final ISourceViewer underlyingSourceViewer;
     private final HighlightingService highlightingService;
     private final SearchAndReplaceService searchAndReplaceService;
     private final VrapperModeRecorder vrapperModeRecorder;
@@ -71,6 +72,7 @@ public class EclipsePlatform implements Platform {
             BufferAndTabService bufferAndTabService) {
         vrapperModeRecorder = new VrapperModeRecorder();
         underlyingEditor = abstractTextEditor;
+        underlyingSourceViewer = sourceViewer;
         underlyingEditorSettings = new AbstractTextEditorSettings(abstractTextEditor, sourceViewer);
         List<DefaultConfigProvider> configProviders =
                 Collections.singletonList((DefaultConfigProvider)underlyingEditorSettings);
@@ -104,6 +106,10 @@ public class EclipsePlatform implements Platform {
 
     public AbstractTextEditor getUnderlyingEditor() {
         return underlyingEditor;
+    }
+
+    public ISourceViewer getUnderlyingSourceViewer() {
+        return underlyingSourceViewer;
     }
 
     @Override

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/VrapperModeRecorder.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/VrapperModeRecorder.java
@@ -1,5 +1,10 @@
 package net.sourceforge.vrapper.eclipse.platform;
 
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.services.ISourceProviderService;
+
+import net.sourceforge.vrapper.eclipse.activator.VrapperStatusSourceProvider;
 import net.sourceforge.vrapper.vim.VrapperEventAdapter;
 import net.sourceforge.vrapper.vim.modes.EditorMode;
 
@@ -18,6 +23,15 @@ public class VrapperModeRecorder extends VrapperEventAdapter {
     @Override
     public void modeSwitched(EditorMode oldMode, EditorMode currentMode) {
         this.currentMode = currentMode;
+
+        // Fire listeners on source provider so they know the Vrapper mode was changed
+        // This might be triggered for each editor when enabling / disabling Vrapper, but so be it.
+        IWorkbench workbench = PlatformUI.getWorkbench();
+        ISourceProviderService sourceProviderService =
+                (ISourceProviderService) workbench.getService(ISourceProviderService.class);
+        VrapperStatusSourceProvider sourceProvider = (VrapperStatusSourceProvider)
+                sourceProviderService.getSourceProvider(VrapperStatusSourceProvider.SOURCE_CURRENTMODE);
+        sourceProvider.fireEditorModeChange(currentMode);
     }
 
     @Override

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/ui/EclipseCommandLineUI.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/ui/EclipseCommandLineUI.java
@@ -1,8 +1,5 @@
 package net.sourceforge.vrapper.eclipse.ui;
 
-import java.text.NumberFormat;
-import java.util.concurrent.TimeUnit;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CaretEvent;
 import org.eclipse.swt.custom.CaretListener;
@@ -30,7 +27,7 @@ import net.sourceforge.vrapper.vim.register.RegisterContent;
 import net.sourceforge.vrapper.vim.register.RegisterManager;
 import net.sourceforge.vrapper.vim.register.StringRegisterContent;
 
-class EclipseCommandLineUI implements CommandLineUI, IDisposable, CaretListener, SelectionListener {
+public class EclipseCommandLineUI implements CommandLineUI, IDisposable, CaretListener, SelectionListener {
 
     private StyledText commandLineText;
     private Register clipboard;
@@ -116,6 +113,10 @@ class EclipseCommandLineUI implements CommandLineUI, IDisposable, CaretListener,
                 EclipseCommandLineUI.this.widgetSelected(new SelectionEvent(e2));
             }
         });
+    }
+
+    public StyledText getWidget() {
+        return commandLineText;
     }
 
     public boolean isOpen() {
@@ -412,9 +413,9 @@ class EclipseCommandLineUI implements CommandLineUI, IDisposable, CaretListener,
             commandLineText.setCaret(defaultCaret);
         }
     }
-    
-    /** Makes sure that the prompt characters don't get erased when selected. */
-    protected void clipSelection() {
+
+    /** Makes sure that the caret or selection never move into the prompt characters. */
+    public void clipSelection() {
         if (commandLineText.getSelectionCount() > 0) {
             Point sel = commandLineText.getSelection();
             boolean isReversed = commandLineText.getCaretOffset() == sel.x;
@@ -433,6 +434,11 @@ class EclipseCommandLineUI implements CommandLineUI, IDisposable, CaretListener,
                 newSel = new Point(leftOffset, rightOffset);
             }
             commandLineText.setSelection(newSel);
+        } else {
+            int offset = commandLineText.getCaretOffset();
+            if (offset < contentsOffset) {
+                commandLineText.setCaretOffset(contentsOffset);
+            }
         }
     }
 


### PR DESCRIPTION
So this is a rather big one and I currently don't feel like updating the documentation site, so I thought I could make a pull request with info to garner feedback. Help with documenting this is welcome!

---

First things first: a command which recovers the focus for the current editor. As documented in #435 this happens from time to time. I've been testing with the following settings:
![issue_435_key_config](https://user-images.githubusercontent.com/1451362/50287063-a4848d80-0461-11e9-8101-c630f46f71bb.PNG)

Basically press <kbd>Esc</kbd> anywhere in the Eclipse window and the editor will be activated. Obviously, that key would normally be "eaten" so I actually forward whatever key is bound to the command to Vrapper. This command cannot be disabled by toggling Vrapper so I recommend only using it for the current usecase.

---

Next up is one of our biggest pain points: Vrapper is mainly a "hack" by listening for keys sent to the current text editor. Since Eclipse would eat certain keys to trigger Eclipse commands we would tell people to unbind shortcuts so Vrapper could finally see them.

Worry no more. The commandline / search mode now captures Home / End / Next word / Previous Word / Cut / Copy / Paste by default, and everything else should be a matter of configuration through the General > Keys window:

![issue_108_key_config](https://user-images.githubusercontent.com/1451362/50288342-f6c7ad80-0465-11e9-94f9-8f6a6a57ace9.png)

The keys shown here will take precedence on whatever Eclipse has normally bound to them. If you want to add another, just select one of the existing "Send to Vrapper" shortcuts and press **Copy Command**. You can then bind this empty one.

And just to show that I didn't have to unbind anything, here's a screenshot for what my <kbd>Home</kbd> key is currently bound to:

![issue_108_key_config_still_bound](https://user-images.githubusercontent.com/1451362/50288607-af8dec80-0466-11e9-8db1-96707bfa9209.png)

Finally, do notice the **"When"** column and dropdown box because this is where the magic happens. There are 6 values to be used with Vrapper:

* **Vrapper Active** will accept that key when Vrapper is enabled and an editor with Vrapper inside of it is focused. Switching to a graphical editor or a View will disable this key.
* **Vrapper Commandline Opened** (works for Search, Command, Sneak, ... modes), **Vrapper Insert mode Active**, **Vrapper Normal mode Active**, **Vrapper Visual mode Active** all accept keys when Vrapper is enabled and an editor with Vrapper inside is focused. Switching away will disable this key. Also, any key bound for this mode will override whatever is bound to **Vrapper Active**.
* **Vrapper Enabled on a View** will accept that key when you shifted the focus to an Eclipse view. No keys will be sent to Vrapper, but it is reserved for a different kind of shortcut. More on that below.

Additionally Vrapper adds some clutter at the end of the list with the name **ZZ Vrapper's Dummy Contexts**, but those shouldn't be used.

Anyway, to summarize: enable Vrapper and all those keys work, disable it and everything will works as a plain Eclipse install (given you didn't alter the default binds). We should thus be able to close #108.

---

And now for the final feature: we have had requests like #173 of people who would like to use the same modal input in Eclipse's views like the Project Explorer or Search. Sadly, there's no simple base class which Eclipse views extend from like it is the case with Eclipse editors **and** which gives us all the necessary listeners to react to keyboard input.

As a workaround I have come up with something else:

![issue_173_key_config](https://user-images.githubusercontent.com/1451362/50289560-83279f80-0469-11e9-89e3-d62c4d508d1e.PNG)

Basically you have 4 commands (one for each direction) which you can bind to HJKL or any other shortcut. Seeing how these are enabled when **Vrapper Enabled on a View** accepts it, you can then navigate through Package Explorer pressing J / K and Vrapper will translate these into Up / Down key presses.

As a fallback, the code also tries to detect if the focus is on a text field:

![issue_173_focus_textfield](https://user-images.githubusercontent.com/1451362/50289931-7e172000-046a-11e9-97c1-e595db5f7acb.PNG)

In this case the code will see if your shortcut is a plain character (i.e. not triggered by <kbd>F1</kbd> or <kbd>Ctrl+F</kbd> or something) and inserts it into the text field.

If there are any other cases you can always disable Vrapper (the shortcut should stop working so the default behavior is restored), or open a bug ticket to request us to handle it as another special case.