### PR TITLE
Use WeakReference in BufferInfo to allow garbage collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 net.sourceforge.vrapper.update-site/*.jar
 net.sourceforge.vrapper.update-site/features/
 net.sourceforge.vrapper.update-site/plugins/
+.DS_Store

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/BufferInfo.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/BufferInfo.java
@@ -11,10 +11,24 @@ import org.eclipse.ui.part.FileEditorInput;
 
 public class BufferInfo {
     public final int bufferId;
-    public IEditorInput input;
     public final IEditorReference reference;
     public String editorType;
-    public IEditorInput parentInput;
+    
+    /**
+     * We use WeakReferences for IEditorInputs because BufferInfo is used for values
+     * in the WeakHashMap {@link InputInterceptorManager#activeBufferIdMapping} and
+     * values in a WeakHashMap should not have strong references to the keys of the
+     * WeakHashMap, otherwise that prevents keys from being discarded through garbage
+     * collection.
+     * 
+     * From the User's perspective, using strong references here can prevent an
+     * IEditorInput object from being garbage collected long after its editor
+     * has been closed. That can lead to memory exhaustion when the IEditorInput
+     * holds large data objects.
+     */
+    protected WeakReference<IEditorInput> parentInput;
+    protected WeakReference<IEditorInput> input;
+
     /**
      * Editor in which this buffer was last seen. This is only used to know if the editor could have
      * changed to a multi-page editor, in which case we need to do additional checks.
@@ -28,8 +42,8 @@ public class BufferInfo {
     public BufferInfo(int bufferId, IEditorPart editorPart, IEditorInput parentInput,
             String documentType, IEditorInput subResourceInput) {
         this.bufferId = bufferId;
-        this.parentInput = parentInput;
-        this.input = subResourceInput;
+        this.parentInput = new WeakReference<IEditorInput>(parentInput);
+        this.input = new WeakReference<IEditorInput>(subResourceInput);
         this.editorType = documentType;
         this.reference = null;
         this.lastSeenEditor = new WeakReference<IEditorPart>(editorPart);
@@ -46,6 +60,7 @@ public class BufferInfo {
     }
 
     public String getDisplayName() {
+    	final IEditorInput input = getInput();
         if (input instanceof FileEditorInput) {
             FileEditorInput fileInput = (FileEditorInput) input;
             return fileInput.getFile().getFullPath().toFile().getPath();
@@ -56,5 +71,13 @@ public class BufferInfo {
         } else {
             return "?";
         }
+    }
+    
+    public IEditorInput getInput() {
+    	return input.get();
+    }
+
+    public IEditorInput getParentInput() {
+    	return parentInput.get();
     }
 }

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptorManager.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptorManager.java
@@ -624,7 +624,8 @@ public class InputInterceptorManager implements IPartListener2, IPageChangedList
                 if (editorInfo.isSimpleEditor()) {
                     bufferInfo.parentInput = null;
                 } else {
-                    bufferInfo.parentInput = editorInfo.getParentInfo().getCurrent().getEditorInput();
+					bufferInfo.parentInput = new WeakReference<IEditorInput>(
+							editorInfo.getParentInfo().getCurrent().getEditorInput());
                 }
                 bufferInfo.editorType = editorInfo.getTopLevelEditor().getEditorSite().getId();
                 bufferInfo.lastSeenEditor = new WeakReference<IEditorPart>(editorPart);
@@ -661,7 +662,7 @@ public class InputInterceptorManager implements IPartListener2, IPageChangedList
 
         } else if (buffer.input != null && buffer.parentInput == null) {
             try {
-                page.openEditor(buffer.input, buffer.editorType, true,
+                page.openEditor(buffer.getInput(), buffer.editorType, true,
                         IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
             } catch (PartInitException e) {
                 throw new VrapperPlatformException("Failed to activate editor for input "
@@ -673,7 +674,7 @@ public class InputInterceptorManager implements IPartListener2, IPageChangedList
             // partActivated listeners only clobbers the current editor status.
             activationListenerEnabled = false;
             try {
-                IEditorReference[] editors = page.findEditors(buffer.parentInput, buffer.editorType,
+                IEditorReference[] editors = page.findEditors(buffer.getParentInput(), buffer.editorType,
                         IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
                 // Directly activate existing editors as some editor implementations tend to reset
                 // the cursor when "re-opened".
@@ -681,7 +682,7 @@ public class InputInterceptorManager implements IPartListener2, IPageChangedList
                     parentEditor = editors[0].getEditor(true);
                     page.activate(parentEditor);
                 } else {
-                    parentEditor = page.openEditor(buffer.parentInput, buffer.editorType, true,
+                    parentEditor = page.openEditor(buffer.getParentInput(), buffer.editorType, true,
                         IWorkbenchPage.MATCH_ID | IWorkbenchPage.MATCH_INPUT);
                 }
             } catch (PartInitException e) {
@@ -702,7 +703,7 @@ public class InputInterceptorManager implements IPartListener2, IPageChangedList
         IEditorPart parentEditor = parentEditorInfo.getCurrent();
         if (parentEditor instanceof MultiPageEditorPart) {
             MultiPageEditorPart multiPage = (MultiPageEditorPart) parentEditor;
-            IEditorPart[] foundEditors = multiPage.findEditors(buffer.input);
+            IEditorPart[] foundEditors = multiPage.findEditors(buffer.getInput());
             if (foundEditors.length < 1) {
                 throw new VrapperPlatformException("Failed to find inner editor for "
                         + buffer.input + " in parent editor " + parentEditor);

--- a/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseBufferAndTabService.java
+++ b/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseBufferAndTabService.java
@@ -186,9 +186,9 @@ public class EclipseBufferAndTabService implements BufferAndTabService {
                 continue;
             }
             EclipseBuffer eclipseBuffer = new EclipseBuffer(editorInfo);
-            if (currentInput != null && currentInput.equals(editorInfo.input)) {
+            if (currentInput != null && currentInput.equals(editorInfo.getInput())) {
                 eclipseBuffer.markActive();
-            } else if (previousInput != null && previousInput.equals(editorInfo.input)) {
+            } else if (previousInput != null && previousInput.equals(editorInfo.getInput())) {
                 eclipseBuffer.markAlternate();
             }
             result.add(eclipseBuffer);


### PR DESCRIPTION
BufferInfo objects are used as values in the WeakHashMap
InputInterceptorManager.activeBufferIdMapping and IEditorInput as keys
of that map. However values of a WeakHashMap should never have strong
references to the keys of the map, otherwise that prevents keys from
being discarded through garbage collection.

From the User's perspective, this can prevent an IEditorInput object
from being garbage collected long after its editor has been closed,
leading to memory exhaustion when the IEditorInput holds large data
objects.

This patch changes IEditorInput references in BufferInfo from strong to
weak references, allowing for better memory reclaiming.

Fixes #835