### PR TITLE
Add support for switch with buffer name with :buffer

### DIFF
--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/AllTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/AllTests.java
@@ -7,11 +7,13 @@ import net.sourceforge.vrapper.core.tests.cases.KeyMapTests;
 import net.sourceforge.vrapper.core.tests.cases.MacroTests;
 import net.sourceforge.vrapper.core.tests.cases.MotionTests;
 import net.sourceforge.vrapper.core.tests.cases.NormalModeTests;
+import net.sourceforge.vrapper.core.tests.cases.PatternUtilsTests;
 import net.sourceforge.vrapper.core.tests.cases.RemappingTests;
 import net.sourceforge.vrapper.core.tests.cases.SearchModeTests;
 import net.sourceforge.vrapper.core.tests.cases.SimpleKeyStrokeTests;
 import net.sourceforge.vrapper.core.tests.cases.SnapshotTests;
 import net.sourceforge.vrapper.core.tests.cases.StateAndTransitionTests;
+import net.sourceforge.vrapper.core.tests.cases.SwitchBufferCommandTests;
 import net.sourceforge.vrapper.core.tests.cases.UtilityTests;
 import net.sourceforge.vrapper.core.tests.cases.VisualModeTests;
 import net.sourceforge.vrapper.core.tests.cases.VisualModeExclusiveTests;
@@ -38,6 +40,8 @@ import org.junit.runners.Suite;
 	VisualModeExclusiveTests.class,
 	BlockwiseVisualModeTests.class,
 	UtilityTests.class,
+	SwitchBufferCommandTests.class,
+	PatternUtilsTests.class,
 //	VrapperRCTests.class,
 //	TextObjectsUnitTests.class,
 //	CommandUnitTests.class,

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/CommandLineTests.java
@@ -36,6 +36,7 @@ import net.sourceforge.vrapper.vim.commands.MotionCommand;
 import net.sourceforge.vrapper.vim.commands.RetabOperation;
 import net.sourceforge.vrapper.vim.commands.SortOperation;
 import net.sourceforge.vrapper.vim.commands.SubstitutionOperation;
+import net.sourceforge.vrapper.vim.commands.SwitchBufferCommand;
 import net.sourceforge.vrapper.vim.commands.TextObject;
 import net.sourceforge.vrapper.vim.commands.TextOperation;
 import net.sourceforge.vrapper.vim.commands.TextOperationTextObjectCommand;
@@ -346,6 +347,14 @@ public class CommandLineTests extends VimTestCase {
     	command = parser.parseAndExecute(":", "yank A");
     	assertNotNull(command);
     	assertTrue(command instanceof LineRangeOperationCommand);
+    	
+    	command = parser.parseAndExecute(":", "b1");
+    	assertNotNull(command);
+    	assertTrue(command instanceof SwitchBufferCommand);
+    	
+    	command = parser.parseAndExecute(":", "b fileName");
+    	assertNotNull(command);
+    	assertTrue(command instanceof SwitchBufferCommand);
     }
     
     @Test

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/PatternUtilsTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/PatternUtilsTests.java
@@ -1,0 +1,87 @@
+package net.sourceforge.vrapper.core.tests.cases;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import net.sourceforge.vrapper.utils.PatternUtils;
+
+/**
+ * Test cases for {@link PatternUtils}.
+ *
+ */
+public class PatternUtilsTests {
+    
+    /** Test that the dot is escaped */
+    @Test
+    public void shellPatternToRegexDot() {
+        test("file.txt", "file\\.txt");
+    }
+
+    /** Test regex pattern conversion from shell pattern's asterisks */
+    @Test
+    public void shellPatternToRegexAsterisk() {
+        test("***f*il**e****", ".*f.*il.*e.*");
+    }
+
+    /** Test regex pattern conversion from shell pattern's question marks */
+    @Test
+    public void shellPatternToRegexQuestionMark() {
+        test("file???", "file...");
+    }
+    
+    /** Test that the squared brackets are NOT escaped */
+    @Test
+    public void shellPatternToRegexSquaredBracket() {
+        test("file[]", "file[]");
+    }
+    
+    /** Test that the braces {} alone are escaped */
+    @Test
+    public void shellPatternToRegexBracese() {
+        test("fi{le}", "fi\\{le\\}");
+    }
+    
+    /** Test that the commas are NOT escaped */
+    @Test
+    public void shellPatternToRegexComma() {
+        test("fi,le", "fi,le");
+    }
+    
+    /** Test that the slashes are NOT escaped */
+    @Test
+    public void shellPatternToRegexSlashes() {
+        test("folder/file", "folder/file");
+    }
+    
+    /** Test that the backslashes are escaped */
+    @Test
+    public void shellPatternToRegexBacklashes() {
+        test("folder\\file", "folder\\\\file");
+    }
+    
+    /** Test that characters of start/end of line are NOT escaped */
+    @Test
+    public void shellPatternToRegexStartEnd() {
+        test("^file$", "^file$");
+    }
+    
+    /** Test that characters of start/end of line are escaped */
+    @Test
+    public void shellPatternToRegexPipe() {
+        test("file|", "file\\|");
+    }
+    
+    /**
+     * Assert that a converted shell pattern is equals to an expected output 
+     * 
+     * @param pInputShellPattern The shell pattern as input of the test method
+     * @param pExpectedRegexPattern The expected regex pattern as output
+     */
+    private void test(String pInputShellPattern, String pExpectedRegexPattern) {
+        final String actualRegexPattern = PatternUtils.shellPatternToRegexString(pInputShellPattern);
+        
+        assertEquals(pExpectedRegexPattern, actualRegexPattern);
+        
+    }
+}

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/PatternUtilsTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/PatternUtilsTests.java
@@ -38,7 +38,7 @@ public class PatternUtilsTests {
     
     /** Test that the braces {} alone are escaped */
     @Test
-    public void shellPatternToRegexBracese() {
+    public void shellPatternToRegexBraces() {
         test("fi{le}", "fi\\{le\\}");
     }
     
@@ -66,7 +66,7 @@ public class PatternUtilsTests {
         test("^file$", "^file$");
     }
     
-    /** Test that characters of start/end of line are escaped */
+    /** Test that the pipes characters are escaped */
     @Test
     public void shellPatternToRegexPipe() {
         test("file|", "file\\|");
@@ -75,13 +75,13 @@ public class PatternUtilsTests {
     /**
      * Assert that a converted shell pattern is equals to an expected output 
      * 
-     * @param pInputShellPattern The shell pattern as input of the test method
-     * @param pExpectedRegexPattern The expected regex pattern as output
+     * @param inputShellPattern The shell pattern as input of the test method
+     * @param expectedRegexPattern The expected regex pattern as output
      */
-    private void test(String pInputShellPattern, String pExpectedRegexPattern) {
-        final String actualRegexPattern = PatternUtils.shellPatternToRegexString(pInputShellPattern);
+    private void test(String inputShellPattern, String expectedRegexPattern) {
+        final String actualRegexPattern = PatternUtils.shellPatternToRegexString(inputShellPattern);
         
-        assertEquals(pExpectedRegexPattern, actualRegexPattern);
+        assertEquals(expectedRegexPattern, actualRegexPattern);
         
     }
 }

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/SwitchBufferCommandTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/SwitchBufferCommandTests.java
@@ -29,7 +29,7 @@ public class SwitchBufferCommandTests extends VimTestCase {
     }
 
     /**
-     * Test that ":buffer 2" switch to buffer whose ID is 2
+     * Test that ":buffer 2" switches to buffer with ID 2
      * 
      * @throws CommandExecutionException
      */
@@ -52,7 +52,7 @@ public class SwitchBufferCommandTests extends VimTestCase {
     }
 
     /**
-     * Test that ":buffer buffer2" switch to the buffer whose is buffer2
+     * Test that ":buffer fer2" switches to the buffer whose name is "buffer2"
      * 
      * @throws CommandExecutionException
      */
@@ -73,7 +73,7 @@ public class SwitchBufferCommandTests extends VimTestCase {
     }
 
     /**
-     * Test that ":buffer folder/buffer2" switch to the buffer whose is buffer2
+     * Test that ":buffer folder/buffer2" switches to the buffer whose name is "folder/buffer2"
      * 
      * @throws CommandExecutionException
      */
@@ -94,7 +94,7 @@ public class SwitchBufferCommandTests extends VimTestCase {
     }
 
     /**
-     * Test that ":buffer ^buffer2$" switch to the buffer whose is buffer2
+     * Test that ":buffer ^buffer2$" switches to the buffer whose name is "buffer2"
      * 
      * @throws CommandExecutionException
      */
@@ -114,7 +114,7 @@ public class SwitchBufferCommandTests extends VimTestCase {
         verify(bufferAndTabsService).switchBuffer(buffer2);
     }
 
-    /** Test that ":buffer ^ffer2" does not switch to the buffer whose is buffer2 */
+    /** Test that ":buffer ^ffer2" does not switch to the buffer whose name is "buffer2" */
     @Test
     public void testSwitchPatternKoCircumflex() {
         final String input = "^ffer2";
@@ -133,11 +133,11 @@ public class SwitchBufferCommandTests extends VimTestCase {
             cmd.execute(adaptor);
             fail("Exception expected");
         } catch (final CommandExecutionException ex) {
-            assertEquals("E94: No matching buffer for " + input, ex.getMessage());
+            assertEquals("No matching buffer for " + input, ex.getMessage());
         }
     }
 
-    /** Test that ":buffer buff$" does not switch to the buffer whose is buffer2 */
+    /** Test that ":buffer buff$" does not switch to the buffer whose name is "buffer2" */
     @Test
     public void testSwitchPatternKoDollar() {
         final String input = "buff$";
@@ -156,7 +156,7 @@ public class SwitchBufferCommandTests extends VimTestCase {
             cmd.execute(adaptor);
             fail("Exception expected");
         } catch (final CommandExecutionException ex) {
-            assertEquals("E94: No matching buffer for " + input, ex.getMessage());
+            assertEquals("No matching buffer for " + input, ex.getMessage());
         }
     }
 
@@ -179,11 +179,11 @@ public class SwitchBufferCommandTests extends VimTestCase {
             cmd.execute(adaptor);
             fail("Exception expected");
         } catch (final CommandExecutionException ex) {
-            assertEquals("E94: No matching buffer for " + input, ex.getMessage());
+            assertEquals("No matching buffer for " + input, ex.getMessage());
         }
     }
 
-    /** Test that an exception is raised if there is multiple matches */
+    /** Test that an exception is raised if there are multiple matches */
     @Test
     public void testSwitchPatternKoMultipleMatch() {
         final String input = "ffer";
@@ -202,7 +202,7 @@ public class SwitchBufferCommandTests extends VimTestCase {
             cmd.execute(adaptor);
             fail("Exception expected");
         } catch (final CommandExecutionException exception) {
-            assertEquals("E93: More than one match for " + input, exception.getMessage());
+            assertEquals("More than one match for " + input, exception.getMessage());
         }
     }
 }

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/SwitchBufferCommandTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/SwitchBufferCommandTests.java
@@ -1,0 +1,208 @@
+package net.sourceforge.vrapper.core.tests.cases;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import net.sourceforge.vrapper.core.tests.utils.VimTestCase;
+import net.sourceforge.vrapper.platform.Buffer;
+import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
+import net.sourceforge.vrapper.vim.commands.SwitchBufferCommand;
+import net.sourceforge.vrapper.vim.modes.NormalMode;
+
+/**
+ * Test case for {@link SwitchBufferCommand}.
+ *
+ */
+public class SwitchBufferCommandTests extends VimTestCase {
+
+    @Before
+    public void activateNormalMode() {
+        adaptor.changeModeSafely(NormalMode.NAME);
+    }
+
+    /**
+     * Test that ":buffer 2" switch to buffer whose ID is 2
+     * 
+     * @throws CommandExecutionException
+     */
+    @Test
+    public void testSwitchNumber() throws CommandExecutionException {
+        final int expectedBufferId = 2;
+        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getId()).thenReturn(1);
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getId()).thenReturn(2);
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand(String.valueOf(expectedBufferId));
+        cmd.execute(adaptor, expectedBufferId);
+        
+        verify(bufferAndTabsService).switchBuffer(buffer2);
+    }
+
+    /**
+     * Test that ":buffer buffer2" switch to the buffer whose is buffer2
+     * 
+     * @throws CommandExecutionException
+     */
+    @Test
+    public void testSwitchPattern() throws CommandExecutionException {        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand("fer2");
+        cmd.execute(adaptor);
+        
+        verify(bufferAndTabsService).switchBuffer(buffer2);
+    }
+
+    /**
+     * Test that ":buffer folder/buffer2" switch to the buffer whose is buffer2
+     * 
+     * @throws CommandExecutionException
+     */
+    @Test
+    public void testSwitchPatternSlash() throws CommandExecutionException {        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("folder/buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand("older/buf");
+        cmd.execute(adaptor);
+        
+        verify(bufferAndTabsService).switchBuffer(buffer2);
+    }
+
+    /**
+     * Test that ":buffer ^buffer2$" switch to the buffer whose is buffer2
+     * 
+     * @throws CommandExecutionException
+     */
+    @Test
+    public void testSwitchPatternCircumflexDollar() throws CommandExecutionException {        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand("^buffer2$");
+        cmd.execute(adaptor);
+        
+        verify(bufferAndTabsService).switchBuffer(buffer2);
+    }
+
+    /** Test that ":buffer ^ffer2" does not switch to the buffer whose is buffer2 */
+    @Test
+    public void testSwitchPatternKoCircumflex() {
+        final String input = "^ffer2";
+        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand(input);
+
+        try {
+            cmd.execute(adaptor);
+            fail("Exception expected");
+        } catch (final CommandExecutionException ex) {
+            assertEquals("E94: No matching buffer for " + input, ex.getMessage());
+        }
+    }
+
+    /** Test that ":buffer buff$" does not switch to the buffer whose is buffer2 */
+    @Test
+    public void testSwitchPatternKoDollar() {
+        final String input = "buff$";
+        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand(input);
+
+        try {
+            cmd.execute(adaptor);
+            fail("Exception expected");
+        } catch (final CommandExecutionException ex) {
+            assertEquals("E94: No matching buffer for " + input, ex.getMessage());
+        }
+    }
+
+    /** Test that buffer is not found if using bad case */
+    @Test
+    public void testSwitchPatternKoCaseSensitive() {
+        final String input = "FeR2";
+        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand(input);
+        
+        try {
+            cmd.execute(adaptor);
+            fail("Exception expected");
+        } catch (final CommandExecutionException ex) {
+            assertEquals("E94: No matching buffer for " + input, ex.getMessage());
+        }
+    }
+
+    /** Test that an exception is raised if there is multiple matches */
+    @Test
+    public void testSwitchPatternKoMultipleMatch() {
+        final String input = "ffer";
+        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand(input);
+        
+        try {
+            cmd.execute(adaptor);
+            fail("Exception expected");
+        } catch (final CommandExecutionException exception) {
+            assertEquals("E93: More than one match for " + input, exception.getMessage());
+        }
+    }
+}

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/SwitchBufferCommandTests.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/SwitchBufferCommandTests.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import net.sourceforge.vrapper.core.tests.utils.VimTestCase;
 import net.sourceforge.vrapper.platform.Buffer;
+import net.sourceforge.vrapper.vim.Options;
 import net.sourceforge.vrapper.vim.commands.CommandExecutionException;
 import net.sourceforge.vrapper.vim.commands.SwitchBufferCommand;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
@@ -181,6 +182,28 @@ public class SwitchBufferCommandTests extends VimTestCase {
         } catch (final CommandExecutionException ex) {
             assertEquals("No matching buffer for " + input, ex.getMessage());
         }
+    }
+
+    /** Test that buffer is found if bad case and case insensitivity is set 
+     * @throws CommandExecutionException */
+    @Test
+    public void testSwitchPatternOkCaseInsensitive() throws CommandExecutionException {
+        final String input = "FeR2";
+
+        when(configuration.get(Options.FILE_IGNORE_CASE)).thenReturn(true);
+        
+        final Buffer buffer1 = mock(Buffer.class);
+        when(buffer1.getDisplayName()).thenReturn("buffer1");
+        
+        final Buffer buffer2 = mock(Buffer.class);
+        when(buffer2.getDisplayName()).thenReturn("buffer2");
+        
+        when(bufferAndTabsService.getBuffers()).thenReturn(Arrays.asList(buffer1, buffer2));
+        
+        final SwitchBufferCommand cmd = new SwitchBufferCommand(input);
+        cmd.execute(adaptor);
+        
+        verify(bufferAndTabsService).switchBuffer(buffer2);
     }
 
     /** Test that an exception is raised if there are multiple matches */

--- a/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/utils/VimTestCase.java
+++ b/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/utils/VimTestCase.java
@@ -12,6 +12,7 @@ import net.sourceforge.vrapper.keymap.SpecialKey;
 import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.platform.Configuration.Option;
 import net.sourceforge.vrapper.platform.Configuration.OptionScope;
+import net.sourceforge.vrapper.platform.BufferAndTabService;
 import net.sourceforge.vrapper.platform.FileService;
 import net.sourceforge.vrapper.platform.GlobalConfiguration;
 import net.sourceforge.vrapper.platform.HistoryService;
@@ -59,6 +60,7 @@ public class VimTestCase {
     @Mock protected ServiceProvider serviceProvider;
     @Mock protected PlatformSpecificStateProvider platformSpecificStateProvider;
     @Mock protected UnderlyingEditorSettings underlyingEditorSettings;
+    @Mock protected BufferAndTabService bufferAndTabsService;
     private GlobalConfiguration globalConfiguration;
     protected LocalConfiguration configuration;
     protected TestTextContent content;
@@ -122,6 +124,7 @@ public class VimTestCase {
         when(platform.getPlatformSpecificStateProvider(Mockito.<TextObjectProvider>any()))
                 .thenReturn(platformSpecificStateProvider);
         when(platform.getUnderlyingEditorSettings()).thenReturn(underlyingEditorSettings);
+        when(platform.getBufferAndTabService()).thenReturn(bufferAndTabsService);
         reloadEditorAdaptor();
         defaultRegister = spy(new SimpleRegister());
         lastEditRegister = spy(new SimpleRegister());

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/PatternUtils.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/PatternUtils.java
@@ -11,11 +11,11 @@ public class PatternUtils {
      * <br>
      * If this method throw a PatternSyntaxException, then there is a problem to fix in the callee, here.
      * 
-     * @param pShellPattern The shell pattern
+     * @param shellPattern The shell pattern
      * @return A regex pattern
      */
-    public static Pattern shellPatternToRegex(final String pShellPattern) {
-        final String regex = "^.*" + shellPatternToRegexString(pShellPattern) + ".*$";
+    public static Pattern shellPatternToRegex(final String shellPattern) {
+        final String regex = "^.*" + shellPatternToRegexString(shellPattern) + ".*$";
         return Pattern.compile(regex);
     }
     
@@ -32,11 +32,11 @@ public class PatternUtils {
      * <li>{a,b} is replaced by \{a,b\} and not by \(a|b\) (Vim behaviour)</li>
      * </ul>
      * 
-     * @param pShellPattern The shell pattern
+     * @param shellPattern The shell pattern
      * @return A regex pattern
      */
-    public static String shellPatternToRegexString(final String pShellPattern) {        
-        String escapedPattern = pShellPattern
+    public static String shellPatternToRegexString(final String shellPattern) {        
+        String escapedPattern = shellPattern
             .replaceAll("\\*{2,}", "*")
             .replace("\\", "\\\\")            
             .replace("|", "\\|")

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/PatternUtils.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/PatternUtils.java
@@ -12,11 +12,18 @@ public class PatternUtils {
      * If this method throw a PatternSyntaxException, then there is a problem to fix in the callee, here.
      * 
      * @param shellPattern The shell pattern
+     * @param isCaseSensitive Is the pattern must be case sensitive?
      * @return A regex pattern
      */
-    public static Pattern shellPatternToRegex(final String shellPattern) {
+    public static Pattern shellPatternToRegex(String shellPattern, boolean isCaseSensitive) {
         final String regex = "^.*" + shellPatternToRegexString(shellPattern) + ".*$";
-        return Pattern.compile(regex);
+        
+        int flags = 0;
+        if (isCaseSensitive) {
+            flags |= Pattern.CASE_INSENSITIVE;
+        }
+        
+        return Pattern.compile(regex, flags);
     }
     
     /**
@@ -35,7 +42,7 @@ public class PatternUtils {
      * @param shellPattern The shell pattern
      * @return A regex pattern
      */
-    public static String shellPatternToRegexString(final String shellPattern) {        
+    public static String shellPatternToRegexString(String shellPattern) {        
         String escapedPattern = shellPattern
             .replaceAll("\\*{2,}", "*")
             .replace("\\", "\\\\")            

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/PatternUtils.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/PatternUtils.java
@@ -1,0 +1,57 @@
+package net.sourceforge.vrapper.utils;
+
+import java.util.regex.Pattern;
+
+/** Util class related to patterns (eg. regex) */
+public class PatternUtils {
+    
+    /**
+     * Convert a shell pattern (containing for example wildcards *) to a regular expression.<br>
+     * Source Vim: src/fileio.c : file_pat_to_reg_pat()<br>
+     * <br>
+     * If this method throw a PatternSyntaxException, then there is a problem to fix in the callee, here.
+     * 
+     * @param pShellPattern The shell pattern
+     * @return A regex pattern
+     */
+    public static Pattern shellPatternToRegex(final String pShellPattern) {
+        final String regex = "^.*" + shellPatternToRegexString(pShellPattern) + ".*$";
+        return Pattern.compile(regex);
+    }
+    
+    /**
+     * Convert a shell pattern (containing for example wildcards *) to a regular expression.<br>
+     * Source Vim: src/fileio.c : file_pat_to_reg_pat()<br>
+     * <br>
+     * Some unclear Vim behaviours are kept:
+     * <ul>
+     * <li>^ and $ are not escaped</li>
+     * </ul>
+     * While others are changed:
+     * <ul>
+     * <li>{a,b} is replaced by \{a,b\} and not by \(a|b\) (Vim behaviour)</li>
+     * </ul>
+     * 
+     * @param pShellPattern The shell pattern
+     * @return A regex pattern
+     */
+    public static String shellPatternToRegexString(final String pShellPattern) {        
+        String escapedPattern = pShellPattern
+            .replaceAll("\\*{2,}", "*")
+            .replace("\\", "\\\\")            
+            .replace("|", "\\|")
+            .replace(".", "\\.")
+            .replace("*", ".*")
+            .replace('?', '.')
+            .replace("(", "\\(")
+            .replace(")", "\\)")
+            .replace("{", "\\{")
+            .replace("}", "\\}");
+        
+        return escapedPattern;
+    }
+    
+    /** Private constructor to prevent instanciation since it is an Utils class */
+    private PatternUtils() {}
+
+}

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/StringUtils.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/StringUtils.java
@@ -186,10 +186,10 @@ public class StringUtils {
     }
     
     /** Is the parameter integer?
-     * @param pString String to test
+     * @param potentialInteger String to test
      * @return true if the parameter can be parsed to integer
      */
-    public static boolean isInteger(String pString) {
-        return INTEGER_PATTERN.matcher(pString).matches();
+    public static boolean isInteger(String potentialInteger) {
+        return INTEGER_PATTERN.matcher(potentialInteger).matches();
     }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/StringUtils.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/StringUtils.java
@@ -3,8 +3,13 @@ package net.sourceforge.vrapper.utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class StringUtils {
+    
+    /** Pattern to identify an integer as a string */
+    private static Pattern INTEGER_PATTERN = Pattern.compile("^-?\\d+$");
+    
     public static String multiply(String str, int count) {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < count; i++) {
@@ -178,5 +183,13 @@ public class StringUtils {
             currentPatternNum++;
         }
         return result;
+    }
+    
+    /** Is the parameter integer?
+     * @param pString String to test
+     * @return true if the parameter can be parsed to integer
+     */
+    public static boolean isInteger(String pString) {
+        return INTEGER_PATTERN.matcher(pString).matches();
     }
 }

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
@@ -13,19 +13,20 @@ import net.sourceforge.vrapper.vim.register.RegisterManager;
 
 public interface Options {
     // Boolean options:
-    public static final Option<Boolean> SMART_INDENT          = bool("smartindent",  true,  "si");
-    public static final Option<Boolean> AUTO_INDENT           = bool("autoindent",   false, "ai");
-    public static final Option<Boolean> ATOMIC_INSERT         = bool("atomicinsert", true,  "ati");
-    public static final Option<Boolean> IGNORE_CASE           = bool("ignorecase",   false, "ic");
-    public static final Option<Boolean> SMART_CASE            = bool("smartcase",    false, "scs");
-    public static final Option<Boolean> SEARCH_HIGHLIGHT= globalBool("hlsearch",     false, "hls");
-    public static final Option<Boolean> SEARCH_REGEX          = bool("regexsearch",  true,  "rxs");
-    public static final Option<Boolean> INCREMENTAL_SEARCH    = bool("incsearch",    false, "is");
-    public static final Option<Boolean> IM_DISABLE            = bool("imdisable",    false, "imd");
-    public static final Option<Boolean> VISUAL_MOUSE          = bool("visualmouse",  true,  "vm");
-    public static final Option<Boolean> EXIT_LINK_MODE        = bool("exitlinkmode", true,  "elm");
-    public static final Option<Boolean> CLEAN_INDENT          = bool("cleanindent",  true);
-    public static final Option<Boolean> AUTO_CHDIR            = bool("autochdir",    false, "acd");
+    public static final Option<Boolean> SMART_INDENT          = bool("smartindent",    true,  "si");
+    public static final Option<Boolean> AUTO_INDENT           = bool("autoindent",     false, "ai");
+    public static final Option<Boolean> ATOMIC_INSERT         = bool("atomicinsert",   true,  "ati");
+    public static final Option<Boolean> IGNORE_CASE           = bool("ignorecase",     false, "ic");
+    public static final Option<Boolean> FILE_IGNORE_CASE      = bool("fileignorecase", false, "fic");
+    public static final Option<Boolean> SMART_CASE            = bool("smartcase",      false, "scs");
+    public static final Option<Boolean> SEARCH_HIGHLIGHT= globalBool("hlsearch",       false, "hls");
+    public static final Option<Boolean> SEARCH_REGEX          = bool("regexsearch",    true,  "rxs");
+    public static final Option<Boolean> INCREMENTAL_SEARCH    = bool("incsearch",      false, "is");
+    public static final Option<Boolean> IM_DISABLE            = bool("imdisable",      false, "imd");
+    public static final Option<Boolean> VISUAL_MOUSE          = bool("visualmouse",    true,  "vm");
+    public static final Option<Boolean> EXIT_LINK_MODE        = bool("exitlinkmode",   true,  "elm");
+    public static final Option<Boolean> CLEAN_INDENT          = bool("cleanindent",    true);
+    public static final Option<Boolean> AUTO_CHDIR            = bool("autochdir",      false, "acd");
     // TODO: This is an Eclipse setting under Window->Preferences->Editors->Text Editors->"Insert spaces for tabs"
     //       Changing this value should change the Eclipse configuration too. -- BRD
     public static final Option<Boolean> EXPAND_TAB            = bool("expandtab",    true,  "et");
@@ -46,7 +47,7 @@ public interface Options {
     @SuppressWarnings("unchecked")
     public static final Set<Option<Boolean>> BOOLEAN_OPTIONS = set(
             EXPAND_TAB, SHIFT_ROUND, SMART_INDENT, AUTO_INDENT, ATOMIC_INSERT, IGNORE_CASE,
-            SMART_CASE, SEARCH_HIGHLIGHT, SEARCH_REGEX,
+            FILE_IGNORE_CASE, SMART_CASE, SEARCH_HIGHLIGHT, SEARCH_REGEX,
             INCREMENTAL_SEARCH, LINE_NUMBERS, SHOW_WHITESPACE, IM_DISABLE,
             VISUAL_MOUSE, EXIT_LINK_MODE, CLEAN_INDENT, AUTO_CHDIR, HIGHLIGHT_CURSOR_LINE,
             CONTENT_ASSIST_MODE, START_NORMAL_MODE, UNDO_MOVES_CURSOR, DEBUGLOG, MODIFIABLE,

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwitchBufferCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwitchBufferCommand.java
@@ -1,17 +1,15 @@
 package net.sourceforge.vrapper.vim.commands;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import net.sourceforge.vrapper.platform.Buffer;
 import net.sourceforge.vrapper.platform.BufferAndTabService;
 import net.sourceforge.vrapper.utils.PatternUtils;
 import net.sourceforge.vrapper.utils.StringUtils;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.Options;
 
 
 public class SwitchBufferCommand extends CountAwareCommand {
@@ -67,7 +65,8 @@ public class SwitchBufferCommand extends CountAwareCommand {
             }
             
         } else {
-            switchBufferName(batService);
+            final boolean isCaseSensitive = editorAdaptor.getConfiguration().get(Options.FILE_IGNORE_CASE);
+            switchBufferName(batService, isCaseSensitive);
         }
     }
     
@@ -94,10 +93,11 @@ public class SwitchBufferCommand extends CountAwareCommand {
     /** Switch to a buffer whose name matches the command argument (a substring)<br>
      * Source Vim: src/buffer.c
      * @param bufferService Service to use for buffer switching
+     * @param isCaseSensitive Is the buffer searching is case sensitive?
      * @throws CommandExecutionException In case of non unique or inexistant buffer name
      */
-    private void switchBufferName(BufferAndTabService bufferService) throws CommandExecutionException {
-        final Pattern pattern = PatternUtils.shellPatternToRegex(targetBuffer);
+    private void switchBufferName(BufferAndTabService bufferService, boolean isCaseSensitive) throws CommandExecutionException {
+        final Pattern pattern = PatternUtils.shellPatternToRegex(targetBuffer, isCaseSensitive);
         
         final List<Buffer> matchingBuffers = new ArrayList<Buffer>();
         

--- a/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwitchBufferCommand.java
+++ b/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SwitchBufferCommand.java
@@ -72,36 +72,36 @@ public class SwitchBufferCommand extends CountAwareCommand {
     }
     
     /** Switch to a buffer number
-     * @param pBufferService Service to use for buffer switching
-     * @param pTargetBufferId Buffer ID to switch to
+     * @param bufferService Service to use for buffer switching
+     * @param targetBufferId Buffer ID to switch to
      * @throws CommandExecutionException In case of buffer ID not found
      */
-    private void switchBufferNumber(BufferAndTabService pBufferService, int pTargetBufferId) throws CommandExecutionException {
+    private void switchBufferNumber(BufferAndTabService bufferService, int targetBufferId) throws CommandExecutionException {
         int i = 0;
-        List<Buffer> buffers = pBufferService.getBuffers();
-        while (i < buffers.size() && ! new Integer(pTargetBufferId).equals(buffers.get(i).getId())) {
+        List<Buffer> buffers = bufferService.getBuffers();
+        while (i < buffers.size() && targetBufferId != buffers.get(i).getId()) {
             i++;
         }
         
         if (i == buffers.size()) {
-            throw new CommandExecutionException("No buffer found with id " + pTargetBufferId);
+            throw new CommandExecutionException("No buffer found with id " + targetBufferId);
         }
         
         Buffer buffer = buffers.get(i);
-        pBufferService.switchBuffer(buffer);
+        bufferService.switchBuffer(buffer);
     }
     
     /** Switch to a buffer whose name matches the command argument (a substring)<br>
      * Source Vim: src/buffer.c
-     * @param pBufferService Service to use for buffer switching
+     * @param bufferService Service to use for buffer switching
      * @throws CommandExecutionException In case of non unique or inexistant buffer name
      */
-    private void switchBufferName(BufferAndTabService pBufferService) throws CommandExecutionException {
+    private void switchBufferName(BufferAndTabService bufferService) throws CommandExecutionException {
         final Pattern pattern = PatternUtils.shellPatternToRegex(targetBuffer);
         
         final List<Buffer> matchingBuffers = new ArrayList<Buffer>();
         
-        for (Buffer currentBuffer : pBufferService.getBuffers()) {
+        for (Buffer currentBuffer : bufferService.getBuffers()) {
             final String bufferName = currentBuffer.getDisplayName();
             if (pattern.matcher(bufferName).matches()) {
                 matchingBuffers.add(currentBuffer);
@@ -109,12 +109,12 @@ public class SwitchBufferCommand extends CountAwareCommand {
         }
         
         if (matchingBuffers.isEmpty()) {
-            throw new CommandExecutionException("E94: No matching buffer for " + targetBuffer);
+            throw new CommandExecutionException("No matching buffer for " + targetBuffer);
         } else if (matchingBuffers.size() >= 2) {
-            throw new CommandExecutionException("E93: More than one match for " + targetBuffer);
+            throw new CommandExecutionException("More than one match for " + targetBuffer);
         }
         
-        pBufferService.switchBuffer(matchingBuffers.get(0));
+        bufferService.switchBuffer(matchingBuffers.get(0));
     }
 
     @Override

--- a/website/documentation/commandline_commands.html
+++ b/website/documentation/commandline_commands.html
@@ -131,6 +131,13 @@ Vrapper allows abbreviated commands only when there are no conflicts (e.g. custo
         </td>
     </tr>
     <tr>
+        <td>:b[uffer ]&lt;buffer name&gt;</td>
+        <td>
+            Switch to the buffer with the given name. A partial name also works as long as it is unique.
+            See <code>:buffers</code> above.
+        </td>
+    </tr>
+    <tr>
         <td>:bd[elete]</td>
         <td>Close current editor (tab)</td>
     </tr>

--- a/website/documentation/commands.html
+++ b/website/documentation/commands.html
@@ -209,7 +209,6 @@
 		<tr><td>&lt;C-^&gt;</td><td>Switch to previous buffer</td></tr>
 		<tr><td>&lt;C-6&gt;</td><td>Switch to previous buffer</td></tr>
 		<tr><td>&lt;buffer id&gt;&lt;C-6 / C-^&gt;</td><td>Switch to buffer with given id</td></tr>
-		<tr><td>&lt;buffer name&gt</td><td>Switch to buffer with given partial name</td></tr>
     </table>
 
 	<h4 style="margin-bottom:0px">Insert Mode</h4>

--- a/website/documentation/commands.html
+++ b/website/documentation/commands.html
@@ -209,6 +209,7 @@
 		<tr><td>&lt;C-^&gt;</td><td>Switch to previous buffer</td></tr>
 		<tr><td>&lt;C-6&gt;</td><td>Switch to previous buffer</td></tr>
 		<tr><td>&lt;buffer id&gt;&lt;C-6 / C-^&gt;</td><td>Switch to buffer with given id</td></tr>
+		<tr><td>&lt;buffer name&gt</td><td>Switch to buffer with given partial name</td></tr>
     </table>
 
 	<h4 style="margin-bottom:0px">Insert Mode</h4>

--- a/website/documentation/configuration.html
+++ b/website/documentation/configuration.html
@@ -53,6 +53,12 @@
         <td>Whether case should be ignored when searching.</td>
     </tr>
     <tr>
+        <td>:set&nbsp;fileignorecase<br/>:set&nbsp;nofileignorecase</td>
+        <td>:set&nbsp;fic<br/>:set&nbsp;nofic</td>
+        <td>Off</td>
+        <td>Whether case should be ignored when operating on paths and file names (eg. buffer switching <code>:buffer {bufname}</code>)</td>
+    </tr>
+    <tr>
         <td>:set&nbsp;smartcase<br/>:set&nbsp;nosmartcase</td>
         <td>:set&nbsp;scs<br/>:set&nbsp;noscs</td>
         <td>Off</td>


### PR DESCRIPTION
Switching with a partial buffer name is a feature of Vim: https://vimhelp.org/windows.txt.html#%7Bbufname%7D

It is really convenient especially with Eclipse because buffer IDs cannot be known by the user before using `:buffers` or `:ls`. That allows faster buffer switching.

Here is a pull request, I tried to do a quality development by adding some unit tests and verifying expected regex output from shell pattern by debugging Vim (_src/buffer.c:buflist_findpat_ and _src/fileio.c:file_pat_to_reg_pat_).

Any comments of how should I improve further the code is very welcome. I hope to see this feature merged so that other users can benefit from it.

Related issues: #744