### PR TITLE
Implement visual put command which leaves unnamed register untouched

### DIFF
--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/DeleteOperation.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/DeleteOperation.java
@@ -58,6 +58,7 @@ public class DeleteOperation extends SimpleTextOperation implements LineWiseOper
                 Position newPosition = region.getLeftBound().addModelOffset(-(position - previousNewlinePos));
                 region = new StartEndTextRange(newPosition, region.getRightBound());
             }
+            yankAndUpdateLastDelete(editorAdaptor, region, contentType);
             doIt(editorAdaptor, region, contentType);
         } finally {
             editorAdaptor.getHistory().endCompoundChange();
@@ -67,18 +68,24 @@ public class DeleteOperation extends SimpleTextOperation implements LineWiseOper
     public TextOperation repetition() {
         return this;
     }
+    
+    public static void yankAndUpdateLastDelete(EditorAdaptor editorAdaptor, TextRange range, ContentType contentType) {
+        if(range == null) {
+            return;
+        }
 
-    public static void doIt(EditorAdaptor editorAdaptor, TextRange range, ContentType contentType) {
-    	if(range == null) {
-    		return;
-    	}
-    	
         YankOperation.doIt(editorAdaptor, range, contentType, false);
         RegisterManager registerManager = editorAdaptor.getRegisterManager();
         if(registerManager.isDefaultRegisterActive()) {
-        	//get what YankOperation just set
-        	RegisterContent register = registerManager.getActiveRegister().getContent();
-        	registerManager.setLastDelete(register);
+            //get what YankOperation just set
+            RegisterContent register = registerManager.getActiveRegister().getContent();
+            registerManager.setLastDelete(register);
+        }
+    }
+
+    public static void doIt(EditorAdaptor editorAdaptor, TextRange range, ContentType contentType) {
+        if(range == null) {
+            return;
         }
 
         TextContent txtContent = editorAdaptor.getModelContent();

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/AbstractVisualMode.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/AbstractVisualMode.java
@@ -192,7 +192,8 @@ public abstract class AbstractVisualMode extends CommandBasedMode {
         final Command leaveVisual = LeaveVisualModeCommand.INSTANCE;
         final Command yank   = new SelectionBasedTextOperationCommand(YankOperation.INSTANCE);
         final Command delete = new SelectionBasedTextOperationCommand(DeleteOperation.INSTANCE);
-        final Command paste  = new SelectionBasedTextOperationCommand(PasteOperation.INSTANCE);
+        final Command replaceYank  = new SelectionBasedTextOperationCommand(PasteOperation.REPLACE_YANK);
+        final Command replace  = new SelectionBasedTextOperationCommand(PasteOperation.REPLACE);
         final Command change = new SelectionBasedTextOperationCommand.DontChangeMode(ChangeOperation.INSTANCE);
         final Command format = new SelectionBasedTextOperationCommand(FormatOperation.INSTANCE);
         final Command shiftLeft = new SelectionBasedTextOperationCommand(InsertShiftWidth.REMOVE_VISUAL);
@@ -224,8 +225,8 @@ public abstract class AbstractVisualMode extends CommandBasedMode {
                 leafBind('x', delete),
                 leafBind('X', delete),
                 leafBind(SpecialKey.DELETE, delete),
-                leafBind('p', paste),
-                leafBind('P', paste),
+                leafBind('p', replaceYank),
+                leafBind('P', replace),
                 leafBind('~', swapCase),
                 leafBind('J', joinLines),
                 leafBind(':', commandLineMode),

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/TempVisualMode.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/TempVisualMode.java
@@ -38,13 +38,15 @@ public class TempVisualMode extends VisualMode implements TemporaryMode {
 
     @Override
     protected State<Command> buildInitialState() {
-        Command pasteTempVisual = new SelectionBasedTextOperationCommand(
-                                        PasteOperation.INSTANCE_TEMPVISUAL);
+        Command replaceYankTempVisual = new SelectionBasedTextOperationCommand(
+                                        PasteOperation.REPLACE_YANK_TEMPVISUAL);
+        Command replaceTempVisual = new SelectionBasedTextOperationCommand(
+                                        PasteOperation.REPLACE_TEMPVISUAL);
 
         return union(super.getPlatformSpecificState(VisualMode.NAME),
                 state(
-                        leafBind('p', pasteTempVisual),
-                        leafBind('P', pasteTempVisual)),
+                        leafBind('p', replaceYankTempVisual),
+                        leafBind('P', replaceTempVisual)),
                 super.buildInitialState());
     }
 }

--- a/tests/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VisualModeTests.java
+++ b/tests/net.sourceforge.vrapper.core.tests/src/net/sourceforge/vrapper/core/tests/cases/VisualModeTests.java
@@ -96,6 +96,49 @@ public class VisualModeTests extends VisualTestCase {
     }
 
     @Test
+    public void testPastingWithoutYankInVisualMode() throws Exception {
+        var defaultRegisterContent = "a series of tubes";
+        defaultRegister.setContent(new StringRegisterContent(ContentType.TEXT, defaultRegisterContent));
+        checkLeavingCommand(forKeySeq("P"),
+                false, "The internet is ","awesome","!",
+                "The internet is a series of tube",'s',"!");
+        assertEquals(NormalMode.NAME, adaptor.getCurrentModeName());
+        assertYanked(ContentType.TEXT, defaultRegisterContent);
+
+        defaultRegisterContent = "\t\ta series of tubes\n";
+        defaultRegister.setContent(new StringRegisterContent(ContentType.LINES, defaultRegisterContent));
+        checkLeavingCommand(forKeySeq("P"),
+                true, "The internet is ","awesome","!",
+                "The internet is \n\t\t",'a'," series of tubes\n!");
+        assertEquals(NormalMode.NAME, adaptor.getCurrentModeName());
+        assertYanked(ContentType.LINES, defaultRegisterContent);
+
+        defaultRegisterContent = "a series of tubes\n";
+        defaultRegister.setContent(new StringRegisterContent(ContentType.LINES, defaultRegisterContent));
+        checkCommand(forKeySeq("P"),
+                false, "The internet is \n","awesome\n","!",
+                false, "The internet is \n","","a series of tubes\n!");
+        assertEquals(NormalMode.NAME, adaptor.getCurrentModeName());
+        assertYanked(ContentType.LINES, defaultRegisterContent);
+
+        defaultRegisterContent = "a series of tubes";
+        defaultRegister.setContent(new StringRegisterContent(ContentType.TEXT, defaultRegisterContent));
+        checkCommand(forKeySeq("P"),
+                false, "The internet is \n","awesome\n","!",
+                false, "The internet is \n","","a series of tubes\n!");
+        assertEquals(NormalMode.NAME, adaptor.getCurrentModeName());
+        assertYanked(ContentType.TEXT, defaultRegisterContent);
+
+        defaultRegisterContent = "a series of tubes";
+        defaultRegister.setContent(new StringRegisterContent(ContentType.TEXT, defaultRegisterContent));
+        checkCommand(forKeySeq("2P"),
+                false, "The internet is ","awesome","!",
+                false, "The internet is a series of tubesa series of tube","","s!");
+        assertEquals(NormalMode.NAME, adaptor.getCurrentModeName());
+        assertYanked(ContentType.TEXT, defaultRegisterContent);
+    }
+
+    @Test
     public void visualModeShouldHaveAName() {
         adaptor.changeModeSafely(VisualMode.NAME);
         assertEquals("visual mode", adaptor.getCurrentModeName());


### PR DESCRIPTION
Starting from Vim 8.2 there's a different between p / P in visual mode. The latter does not modify the unnamed register so that a P command can be repeated several times without it being clobbered by the previously selected text.

See https://vimhelp.org/change.txt.html#v_P .

Closes #873.