### PR TITLE
EXPERIMENTAL eclipse motion textobjects

### DIFF
--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/CursorService.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/platform/CursorService.java
@@ -39,8 +39,8 @@ public interface CursorService {
     boolean shouldStickToEOL();
 
     /**
-     * @return the current position in the text, i.e. where the caret is
-     *         displayed.
+     * @return the current position in the text, i.e. where the caret is displayed. This position
+     * will be corrected for inclusive selection mode if a selection is present.
      */
     Position getPosition();
 

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/SelectionArea.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/SelectionArea.java
@@ -38,6 +38,9 @@ public abstract class SelectionArea implements TextObject {
     public TextObject withCount(final int count) {
 		return this;
 	}
-    
 
+    @Override
+    public TextObject repetition() {
+        return this;
+    }
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/SimpleLineRange.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/utils/SimpleLineRange.java
@@ -179,6 +179,11 @@ public class SimpleLineRange implements LineRange {
     }
 
     @Override
+    public TextObject repetition() {
+        return this;
+    }
+
+    @Override
     public Position getFrom() {
         return from;
     }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -386,6 +386,7 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
 
     @Override
     public void changeMode(final String modeName, final ModeSwitchHint... args) throws CommandExecutionException {
+        VrapperLog.info("Changing from " + currentMode + " to " + modeName + " (last mode = " + lastModeName + ")");
         EditorMode newMode = modeMap.get(modeName);
         if (newMode == null) {
             // Check extension modes

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -386,7 +386,7 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
 
     @Override
     public void changeMode(final String modeName, final ModeSwitchHint... args) throws CommandExecutionException {
-        VrapperLog.info("Changing from " + currentMode + " to " + modeName + " (last mode = " + lastModeName + ")");
+        VrapperLog.debug("Changing from " + currentMode + " to " + modeName + " (last mode = " + lastModeName + ")");
         EditorMode newMode = modeMap.get(modeName);
         if (newMode == null) {
             // Check extension modes

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/DefaultEditorAdaptor.java
@@ -65,6 +65,7 @@ import net.sourceforge.vrapper.vim.modes.LinewiseVisualMode;
 import net.sourceforge.vrapper.vim.modes.ModeSwitchHint;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
 import net.sourceforge.vrapper.vim.modes.ReplaceMode;
+import net.sourceforge.vrapper.vim.modes.SelectMode;
 import net.sourceforge.vrapper.vim.modes.TempLinewiseVisualMode;
 import net.sourceforge.vrapper.vim.modes.TempNormalMode;
 import net.sourceforge.vrapper.vim.modes.TempVisualMode;
@@ -222,6 +223,7 @@ public class DefaultEditorAdaptor implements EditorAdaptor {
                 new LinewiseVisualMode(self),
                 new TempLinewiseVisualMode(self),
                 new BlockwiseVisualMode(self),
+                new SelectMode(self),
                 new InsertMode(self),
                 new ReplaceMode(self),
                 new CommandLineMode(self),

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/EditorAdaptor.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/EditorAdaptor.java
@@ -77,6 +77,10 @@ public interface EditorAdaptor {
     HighlightingService getHighlightingService();
 
     boolean sourceConfigurationFile(String filename);
+    /**
+     * @return the current position in the text, i.e. where the caret is displayed. This position
+     * will be corrected for inclusive selection mode if a selection is present.
+     */
     Position getPosition();
     void setPosition(Position destination, StickyColumnPolicy stickyColumnPolicy);
     void setSelection(Selection selection);

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/MacroRecorder.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/MacroRecorder.java
@@ -73,7 +73,7 @@ public class MacroRecorder {
     /**
      * Notifies the recorder that the given key was pressed.
      */
-    void handleKey(KeyStroke stroke) {
+    public void handleKey(KeyStroke stroke) {
         if (recording) {
             strokes.add(stroke);
         }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
@@ -24,6 +24,7 @@ public interface Options {
     public static final Option<Boolean> INCREMENTAL_SEARCH    = bool("incsearch",      false, "is");
     public static final Option<Boolean> IM_DISABLE            = bool("imdisable",      false, "imd");
     public static final Option<Boolean> VISUAL_MOUSE          = bool("visualmouse",    true,  "vm");
+    public static final Option<Boolean> VISUAL_OTHER          = bool("visualother",  true,  "vo");
     public static final Option<Boolean> EXIT_LINK_MODE        = bool("exitlinkmode",   true,  "elm");
     public static final Option<Boolean> CLEAN_INDENT          = bool("cleanindent",    true);
     public static final Option<Boolean> AUTO_CHDIR            = bool("autochdir",      false, "acd");
@@ -49,7 +50,7 @@ public interface Options {
             EXPAND_TAB, SHIFT_ROUND, SMART_INDENT, AUTO_INDENT, ATOMIC_INSERT, IGNORE_CASE,
             FILE_IGNORE_CASE, SMART_CASE, SEARCH_HIGHLIGHT, SEARCH_REGEX,
             INCREMENTAL_SEARCH, LINE_NUMBERS, SHOW_WHITESPACE, IM_DISABLE,
-            VISUAL_MOUSE, EXIT_LINK_MODE, CLEAN_INDENT, AUTO_CHDIR, HIGHLIGHT_CURSOR_LINE,
+            VISUAL_MOUSE, VISUAL_OTHER, EXIT_LINK_MODE, CLEAN_INDENT, AUTO_CHDIR, HIGHLIGHT_CURSOR_LINE,
             CONTENT_ASSIST_MODE, START_NORMAL_MODE, UNDO_MOVES_CURSOR, DEBUGLOG, MODIFIABLE,
             GLOBAL_REGISTERS, WRAP_SCAN, SPELL);
 

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/Options.java
@@ -24,7 +24,7 @@ public interface Options {
     public static final Option<Boolean> INCREMENTAL_SEARCH    = bool("incsearch",      false, "is");
     public static final Option<Boolean> IM_DISABLE            = bool("imdisable",      false, "imd");
     public static final Option<Boolean> VISUAL_MOUSE          = bool("visualmouse",    true,  "vm");
-    public static final Option<Boolean> VISUAL_OTHER          = bool("visualother",  true,  "vo");
+    public static final Option<Boolean> VISUAL_OTHER          = bool("visualother",  false, "vo");
     public static final Option<Boolean> EXIT_LINK_MODE        = bool("exitlinkmode",   true,  "elm");
     public static final Option<Boolean> CLEAN_INDENT          = bool("cleanindent",    true);
     public static final Option<Boolean> AUTO_CHDIR            = bool("autochdir",      false, "acd");

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/AbstractSelection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/AbstractSelection.java
@@ -9,6 +9,11 @@ import net.sourceforge.vrapper.vim.Options;
 public abstract class AbstractSelection implements Selection {
 
     @Override
+    public TextObject repetition() {
+        return this;
+    }
+
+    @Override
     public Selection reset(EditorAdaptor editorAdaptor, Position from, Position to) {
         boolean isSelectionInclusive = Selection.INCLUSIVE.equals(
                 editorAdaptor.getConfiguration().get(Options.SELECTION));

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/AbstractTextObject.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/AbstractTextObject.java
@@ -8,4 +8,9 @@ public abstract class AbstractTextObject implements TextObject {
     public int getCount() {
         return 1;
     }
+
+    @Override
+    public TextObject repetition() {
+        return this;
+    }
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockWiseSelection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockWiseSelection.java
@@ -204,7 +204,7 @@ public class BlockWiseSelection extends AbstractSelection {
     }
 
     @Override
-    public Selection wrap(EditorAdaptor adaptor, TextRange range) {
+    public Selection syncToTextRange(EditorAdaptor adaptor, TextRange range) {
         // [FIXME] This is incorrect for inc/exclusive mode.
         return new BlockWiseSelection(adaptor, range.getStart(), range.getEnd());
     }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockWiseSelection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/BlockWiseSelection.java
@@ -202,4 +202,10 @@ public class BlockWiseSelection extends AbstractSelection {
     public Selection doReset(EditorAdaptor adaptor, Position from, Position to) {
         return new BlockWiseSelection(adaptor, from, to);
     }
+
+    @Override
+    public Selection wrap(EditorAdaptor adaptor, TextRange range) {
+        // [FIXME] This is incorrect for inc/exclusive mode.
+        return new BlockWiseSelection(adaptor, range.getStart(), range.getEnd());
+    }
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/DummyTextObject.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/DummyTextObject.java
@@ -5,7 +5,7 @@ import net.sourceforge.vrapper.utils.ContentType;
 import net.sourceforge.vrapper.utils.TextRange;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 
-public class DummyTextObject implements TextObject {
+public class DummyTextObject extends AbstractTextObject {
     
     protected TextRange range;
     protected ContentType contentType = ContentType.TEXT;

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/InnerLineTextObject.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/InnerLineTextObject.java
@@ -14,7 +14,7 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
  * Special text object matching the current line from the first non-whitespace charactor to the
  * last non-whitespace character.
  */
-public class InnerLineTextObject implements TextObject {
+public class InnerLineTextObject extends AbstractTextObject {
 
     public TextRange getRegion(EditorAdaptor editorAdaptor, int count) throws CommandExecutionException {
         TextContent model = editorAdaptor.getModelContent();

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/LineWiseSelection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/LineWiseSelection.java
@@ -105,4 +105,10 @@ public class LineWiseSelection extends AbstractSelection {
     public Selection doReset(EditorAdaptor adaptor, Position from, Position to) {
         return new LineWiseSelection(adaptor, from, to);
     }
+
+    @Override
+    public Selection wrap(EditorAdaptor adaptor, TextRange range) {
+        // [FIXME] This is incorrect for inc/exclusive mode.
+        return new LineWiseSelection(adaptor, range.getStart(), range.getEnd());
+    }
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/MultipliedTextObject.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/MultipliedTextObject.java
@@ -40,4 +40,14 @@ public class MultipliedTextObject implements TextObject {
         return count;
     }
 
+    @Override
+    public TextObject repetition() {
+        TextObject repeatedTextObj = textObject.repetition();
+
+        if (repeatedTextObj == null) {
+            return null;
+        } else {
+            return new MultipliedTextObject(count, repeatedTextObj);
+        }
+    }
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/Selection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/Selection.java
@@ -66,5 +66,5 @@ public interface Selection extends TextObject, TextRange {
      * Selection depends on the value of the <code>selection</code> setting.
      * <p> The caller is responsible for making the selection visible.
      */
-    public Selection wrap(EditorAdaptor adaptor, TextRange range);
+    public Selection syncToTextRange(EditorAdaptor adaptor, TextRange range);
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/Selection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/Selection.java
@@ -59,4 +59,12 @@ public interface Selection extends TextObject, TextRange {
      * <p>The caller is responsible for making the selection visible.
      */
     public Selection reset(EditorAdaptor adaptor, Position from, Position to);
+
+    /**
+     * Returns a <b>new</b> Selection object of the same type as the current one but using the
+     * boundaries given by a text range. The passed in textrange is exclusive, the returned
+     * Selection depends on the value of the <code>selection</code> setting.
+     * <p> The caller is responsible for making the selection visible.
+     */
+    public Selection wrap(EditorAdaptor adaptor, TextRange range);
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SelectionBasedTextObjectCommand.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SelectionBasedTextObjectCommand.java
@@ -31,8 +31,11 @@ public class SelectionBasedTextObjectCommand extends TextObjectCommand {
 	public CountAwareCommand repetition() {
 		Command wrappedRepetition = command.repetition();
 		if (wrappedRepetition != null) {
-            return new SelectionBasedTextObjectCommand(wrappedRepetition, textObject);
-        }
+			TextObject textObjRepetition = textObject.repetition();
+			if (textObjRepetition != null) {
+				return new SelectionBasedTextObjectCommand(wrappedRepetition, textObjRepetition);
+			}
+		}
 		return null;
 	}
 

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SimpleSelection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SimpleSelection.java
@@ -161,4 +161,13 @@ public class SimpleSelection extends AbstractSelection {
             return new SimpleSelection(from, to, StartEndTextRange.exclusive(from, to));
         }
     }
+
+    @Override
+    public Selection wrap(EditorAdaptor adaptor, TextRange range) {
+        // [FIXME] This is incorrect for inc/exclusive mode.
+        CursorService cursorService = adaptor.getCursorService();
+        boolean isSelectionInclusive = Selection.INCLUSIVE.equals(
+                adaptor.getConfiguration().get(Options.SELECTION));
+        return new SimpleSelection(cursorService, isSelectionInclusive, range);
+    }
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SimpleSelection.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/SimpleSelection.java
@@ -163,11 +163,17 @@ public class SimpleSelection extends AbstractSelection {
     }
 
     @Override
-    public Selection wrap(EditorAdaptor adaptor, TextRange range) {
-        // [FIXME] This is incorrect for inc/exclusive mode.
-        CursorService cursorService = adaptor.getCursorService();
+    public Selection syncToTextRange(EditorAdaptor adaptor, TextRange range) {
         boolean isSelectionInclusive = Selection.INCLUSIVE.equals(
                 adaptor.getConfiguration().get(Options.SELECTION));
-        return new SimpleSelection(cursorService, isSelectionInclusive, range);
+        Position newTo = adaptor.getPosition();
+        // Selection might have shifted away from original 'from' position. Calculate new one.
+        Position newFrom = range.getStart();
+        // newTo is already adjusted for inclusive selection but 'from' might still need adjusting
+        if (isSelectionInclusive && range.isReversed()) {
+            CursorService cs = adaptor.getCursorService();
+            newFrom = cs.shiftPositionForViewOffset(range.getStart().getViewOffset(), -1, true);
+        }
+        return new SimpleSelection(newFrom, newTo, range);
     }
 }

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/TextObject.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/TextObject.java
@@ -5,7 +5,7 @@ import net.sourceforge.vrapper.utils.ContentType;
 import net.sourceforge.vrapper.utils.TextRange;
 import net.sourceforge.vrapper.vim.EditorAdaptor;
 
-public interface TextObject extends Counted<TextObject> {
+public interface TextObject extends Repeatable<TextObject>, Counted<TextObject> {
 	/**
 	 * Get the range of text which would be selected by this text object.
 	 * @return a {@link TextRange} instance or <tt>null</tt> in case a text selection would make

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/TextOperationTextObjectCommand.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/commands/TextOperationTextObjectCommand.java
@@ -18,8 +18,11 @@ public class TextOperationTextObjectCommand extends CountAwareCommand {
 	public CountAwareCommand repetition() {
 		TextOperation wrappedRepetition = command.repetition();
 		if (wrappedRepetition != null) {
-            return new TextOperationTextObjectCommand(wrappedRepetition, textObject);
-        }
+			TextObject textObjRepetition = textObject.repetition();
+			if (textObjRepetition != null) {
+				return new TextOperationTextObjectCommand(wrappedRepetition, textObjRepetition);
+			}
+		}
 		return null;
 	}
 

--- a/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/SelectMode.java
+++ b/plugins/net.sourceforge.vrapper.core/src/net/sourceforge/vrapper/vim/modes/SelectMode.java
@@ -1,0 +1,23 @@
+package net.sourceforge.vrapper.vim.modes;
+
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+
+public class SelectMode extends InsertMode {
+
+    public static final String NAME = "select mode";
+    public static final String DISPLAY_NAME = "SELECT";
+
+    public SelectMode(EditorAdaptor editorAdaptor) {
+        super(editorAdaptor);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return DISPLAY_NAME;
+    }
+}

--- a/plugins/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/plugins/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -492,6 +492,10 @@
       <motion command-id="org.eclipse.ui.edit.text.goto.wordNext" />
       <motion command-id="org.eclipse.jdt.ui.edit.text.java.goto.next.member" />
       <motion command-id="org.eclipse.jdt.ui.edit.text.java.goto.previous.member" />
+
+      <command command-id="org.eclipse.ui.edit.copy" />
+      <command command-id="org.eclipse.ui.edit.cut" />
+      <command command-id="org.eclipse.ui.edit.paste" />
    </extension>
 </plugin>
 

--- a/plugins/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/plugins/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -6,6 +6,7 @@
    <extension-point id="net.sourceforge.vrapper.eclipse.psmp" name="Platform Specific Mode Provider" schema="schema/net.sourceforge.vrapper.eclipse.psmp.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.pstop" name="Platform Specific TextObject provider" schema="schema/net.sourceforge.vrapper.eclipse.pstop.exsd"/>
    <extension-point id="net.sourceforge.vrapper.eclipse.lifecyclelistener" name="Vrapper Lifecycle Listener" schema="schema/net.sourceforge.vrapper.eclipse.lifecyclelistener.exsd"/>
+   <extension-point id="net.sourceforge.vrapper.eclipse.commandregistry" name="Eclipse Motions and TextObjects Command Registry" schema="schema/net.sourceforge.vrapper.eclipse.commandregistry.exsd"/>
 
    <extension point="org.eclipse.ui.commands">
     <category
@@ -469,7 +470,28 @@
       <key sequence="CTRL+0" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
       <key sequence="CTRL+-" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
       <key sequence="CTRL+=" commandId="net.sourceforge.vrapper.eclipse.commands.vrapperShortcut" contextId="net.sourceforge.vrapper.eclipse.active" schemeId="net.sourceforge.vrapper.keyscheme"/>
+   </extension>
 
-     </extension>
+   <extension point="net.sourceforge.vrapper.eclipse.commandregistry">
+      <textobject command-id="org.eclipse.jdt.ui.edit.text.java.select.enclosing" />
+      <textobject command-id="org.eclipse.jdt.ui.edit.text.java.select.last" />
+      <textobject command-id="org.eclipse.jdt.ui.edit.text.java.select.next" />
+      <textobject command-id="org.eclipse.jdt.ui.edit.text.java.select.previous" />
+      <textobject command-id="org.eclipse.ui.edit.selectAll" />
+      <textobject command-id="org.eclipse.ui.edit.text.moveLineUp" />
+      <textobject command-id="org.eclipse.ui.edit.text.moveLineDown" />
+      <textobject command-id="org.eclipse.ui.edit.text.select.wordPrevious" />
+      <textobject command-id="org.eclipse.ui.edit.text.select.wordNext" />
+      <textobject command-id="org.eclipse.ui.edit.text.select.lineStart" />
+      <textobject command-id="org.eclipse.ui.edit.text.select.lineEnd" />
+
+      <motion command-id="org.eclipse.ui.edit.text.goto.lineStart" restricted-to-line="true" />
+      <motion command-id="org.eclipse.ui.edit.text.goto.lineEnd" restricted-to-line="true" />
+      <motion command-id="org.eclipse.jdt.ui.edit.text.java.goto.matching.bracket" restricted-to-line="true" />
+      <motion command-id="org.eclipse.ui.edit.text.goto.wordPrevious" />
+      <motion command-id="org.eclipse.ui.edit.text.goto.wordNext" />
+      <motion command-id="org.eclipse.jdt.ui.edit.text.java.goto.next.member" />
+      <motion command-id="org.eclipse.jdt.ui.edit.text.java.goto.previous.member" />
+   </extension>
 </plugin>
 

--- a/plugins/net.sourceforge.vrapper.eclipse/plugin.xml
+++ b/plugins/net.sourceforge.vrapper.eclipse/plugin.xml
@@ -484,6 +484,8 @@
       <textobject command-id="org.eclipse.ui.edit.text.select.wordNext" />
       <textobject command-id="org.eclipse.ui.edit.text.select.lineStart" />
       <textobject command-id="org.eclipse.ui.edit.text.select.lineEnd" />
+      <textobject command-id="org.eclipse.ui.navigate.next" />
+      <textobject command-id="org.eclipse.ui.navigate.previous" />
 
       <motion command-id="org.eclipse.ui.edit.text.goto.lineStart" restricted-to-line="true" />
       <motion command-id="org.eclipse.ui.edit.text.goto.lineEnd" restricted-to-line="true" />

--- a/plugins/net.sourceforge.vrapper.eclipse/schema/net.sourceforge.vrapper.eclipse.commandregistry.exsd
+++ b/plugins/net.sourceforge.vrapper.eclipse/schema/net.sourceforge.vrapper.eclipse.commandregistry.exsd
@@ -1,0 +1,149 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="net.sourceforge.vrapper.eclipse" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="net.sourceforge.vrapper.eclipse" id="net.sourceforge.vrapper.eclipse.commandregistry" name="Eclipse Motions and TextObjects Command Registry"/>
+      </appInfo>
+      <documentation>
+         Extension which registers Eclipse command ids which implement motions or textobjects. Vrapper will watch these to correct its internal state.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <choice>
+               <element ref="command"/>
+               <element ref="motion"/>
+               <element ref="textobject"/>
+            </choice>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="command">
+      <annotation>
+         <documentation>
+            Represents any other command which might need to be recorded for use in a macro.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="command-id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="motion">
+      <annotation>
+         <documentation>
+            Registers an Eclipse Command as a motion. Vrapper will expect that this command sets no selection.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="command-id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="restricted-to-line" type="boolean">
+            <annotation>
+               <documentation>
+                  Whether this motion should move to the next line if it wants to navigato to the end-of-line in Normal mode. Not applicable for Visual mode or operators.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="textobject">
+      <annotation>
+         <documentation>
+            Registers an Eclipse Command as a textobject. The command can have side-effects like moving a line, the only requirement is that it properly updates the current selection.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="command-id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         0.66.0
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="apiinfo"/>
+      </appInfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="implementation"/>
+      </appInfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -41,6 +41,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.prefs.BackingStoreException;
 
+import net.sourceforge.vrapper.eclipse.interceptor.EclipseCommandRegistry;
 import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
 import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptorManager;
 import net.sourceforge.vrapper.eclipse.interceptor.UnknownEditorException;
@@ -134,6 +135,10 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
 
     private void preShutdown() throws BackingStoreException {
     	storeVimEmulationOfActiveEditors();
+    }
+
+    void activateExtensions() {
+        EclipseCommandRegistry.INSTANCE.loadExtensionDeclarations();
     }
 
     void restoreVimEmulationInActiveEditors() {

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -5,6 +5,10 @@ import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.expressions.ExpressionInfo;
 import org.eclipse.core.expressions.IEvaluationContext;
 import org.eclipse.core.runtime.CoreException;
+import net.sourceforge.vrapper.eclipse.commands.EclipseMotionPlugState;
+import net.sourceforge.vrapper.eclipse.commands.EclipsePlugState;
+import net.sourceforge.vrapper.eclipse.commands.EclipseTextObjectPlugState;
+import net.sourceforge.vrapper.keymap.vim.PlugKeyStroke;
 import net.sourceforge.vrapper.platform.SelectionService;
 import net.sourceforge.vrapper.utils.TextRange;
 import net.sourceforge.vrapper.vim.commands.Selection;
@@ -20,6 +24,7 @@ import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.adaptor.EclipseStarter;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -417,6 +422,9 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
                 if (nativeSelection.getModelLength() > 0
                         && nativeSelection != SelectionService.VRAPPER_SELECTION_ACTIVE
                         && ! (adaptor.getCurrentMode() instanceof AbstractCommandLineMode)) {
+                    // Record action plug in current macro
+                    // [TODO] Don't do this when EclipseCommand is invoked from Vrapper
+                    adaptor.getMacroRecorder().handleKey(new PlugKeyStroke(EclipseTextObjectPlugState.TEXTOBJPREFIX + commandId + ')'));
                     if (lastSelection == null) {
                         lastSelection = new SimpleSelection(nativeSelection);
                     }
@@ -437,6 +445,9 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
                         // [TODO] Check for inclusive / exclusive!
                         adaptor.setSelection(lastSelection);
                     } else {
+                        // Record action plug in current macro
+                        // [TODO] Don't do this when EclipseCommand is invoked from Vrapper
+                        adaptor.getMacroRecorder().handleKey(new PlugKeyStroke(EclipseMotionPlugState.MOTIONPREFIX + commandId + ')'));
                         // [TODO] Check for inclusive / exclusive!
                         lastSelection = lastSelection.reset(adaptor, lastSelection.getFrom(), adaptor.getPosition());
                         adaptor.setSelection(lastSelection);

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -74,21 +74,21 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
     private static final String KEY_VRAPPER_ENABLED = "vrapperEnabled";
 
     private static final String COMMAND_TOGGLE_VRAPPER = "net.sourceforge.vrapper.eclipse.commands.toggle";
-    
+
     private static final IPreferencesService PREFERENCES_SERVICE = Platform.getPreferencesService();
     // private static final IEclipsePreferences PLUGIN_PREFERENCES = InstanceScope.INSTANCE.getNode(PLUGIN_ID);
-    /* XXX: The "new way" of creating InstanceScope was introduced in Eclipse Juno (4.2) so moving to the new way 
-     * 		would actually break all backwards compatibility with the 3.x series of Eclipse. I'd rather not do 
-     * 		that just yet. There are other solutions based on Eclipse (e.g., Aptana and Flash Builder) which are 
-     *	    still on a 3.x version of Eclipse and I don't want to break Vrapper for all of those users until I 
-     *      have to. I want to give everyone as long as possible to move to the 4.x series of Eclipse. 
+    /* XXX: The "new way" of creating InstanceScope was introduced in Eclipse Juno (4.2) so moving to the new way
+     * 		would actually break all backwards compatibility with the 3.x series of Eclipse. I'd rather not do
+     * 		that just yet. There are other solutions based on Eclipse (e.g., Aptana and Flash Builder) which are
+     *	    still on a 3.x version of Eclipse and I don't want to break Vrapper for all of those users until I
+     *      have to. I want to give everyone as long as possible to move to the 4.x series of Eclipse.
      *      -- Github exchange with keforbes on why we're leaving this alone for now.
      */
     @SuppressWarnings("deprecation") // See note above
     private static final IEclipsePreferences PLUGIN_PREFERENCES = new InstanceScope().getNode(PLUGIN_ID);
 
 	private static final MouseButtonListener MOUSEBUTTON = new MouseButtonListener();
-	
+
 	private final static CommandExecutionListener executionListener = new CommandExecutionListener();
 
     private boolean debugLogEnabled = Boolean.parseBoolean(System.getProperty(DEBUGLOG_PROPERTY))
@@ -156,7 +156,7 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
                 }
             }
         }
-            
+
         addEditorListeners();
     }
 
@@ -185,7 +185,7 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
         window.getWorkbench().getDisplay().addFilter(SWT.MouseDown, MOUSEBUTTON);
         window.getWorkbench().getDisplay().addFilter(SWT.MouseUp, MOUSEBUTTON);
     }
-    
+
     void addShutdownListener() {
         PlatformUI.getWorkbench().addWorkbenchListener(new IWorkbenchListener() {
             public void postShutdown(IWorkbench arg0) { }
@@ -303,7 +303,7 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
         }
 
     }
-    
+
     public void info(String msg) {
         log(IStatus.INFO, msg, null);
     }
@@ -347,24 +347,24 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
             }
         }
     }
-    
+
     public static boolean isVrapperEnabled() {
         return vrapperEnabled;
     }
-    
+
     public static boolean isMouseDown() {
     	return MOUSEBUTTON.down;
     }
-    
+
     public static class CommandExecutionListener implements IExecutionListenerWithChecks {
-    
+
         protected boolean needsCleanup;
         protected Selection lastSelection;
 
         @Override
         public void notHandled(String commandId, NotHandledException exception) {
             // TODO Auto-generated method stub
-            VrapperLog.info("Non-handled command: " + commandId + ". Ex: " + exception.getMessage());
+            VrapperLog.debug("Non-handled command: " + commandId + ". Ex: " + exception.getMessage());
             needsCleanup = false;
         }
 
@@ -372,13 +372,13 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
         public void postExecuteFailure(String commandId,
                 ExecutionException exception) {
             // TODO Auto-generated method stub
-            VrapperLog.info("Failed command: " + commandId + ". Ex: " + exception.getMessage());
+            VrapperLog.debug("Failed command: " + commandId + ". Ex: " + exception.getMessage());
             needsCleanup = false;
         }
 
         @Override
         public void postExecuteSuccess(String commandId, Object returnValue) {
-            VrapperLog.info("Ok command: " + commandId + ". Returns: " + returnValue);
+            VrapperLog.debug("Ok command: " + commandId + ". Returns: " + returnValue);
             if ( ! VrapperPlugin.isVrapperEnabled()) {
                 return;
             }
@@ -444,7 +444,7 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
         public void preExecute(final String commandId, ExecutionEvent event) {
             // TODO Auto-generated method stub
             IWorkbenchPart activePart = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart();
-            VrapperLog.info("PRE command: " + commandId + " in " + activePart + ". Event: " + event);
+            VrapperLog.debug("PRE command: " + commandId + " in " + activePart + ". Event: " + event);
             needsCleanup = true;
             // Always reset this
             lastSelection = null;
@@ -456,7 +456,7 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
             // Chop off that last character if selection is left-to-right and command is a motion.
             IEditorPart activeEditor = HandlerUtil.getActiveEditor(event);
             if (activeEditor == null) {
-                VrapperLog.info("No active editor info in event!");
+                VrapperLog.debug("No active editor info in event!");
                 activeEditor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
             }
             if (activeEditor == null) {
@@ -479,42 +479,42 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
                 if (selRange == SelectionService.VRAPPER_SELECTION_ACTIVE) {
                     // This is the generic part: store Vrapper selection so that 'gv' works.
                     interceptor.getEditorAdaptor().rememberLastActiveSelection();
-                    VrapperLog.info("Stored Vrapper selection");
+                    VrapperLog.debug("Stored Vrapper selection");
                 }
                 // Store current selection so that postExecuteSuccess can update it.
                 lastSelection = interceptor.getEditorAdaptor().getSelection();
-                VrapperLog.info("Grabbed selection");
+                VrapperLog.debug("Grabbed selection");
             }
             Display.getCurrent().asyncExec(new Runnable() {
                 @Override
                 public void run() {
                     // TODO Auto-generated method stub
                     IWorkbenchPart activePart = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart();
-                    VrapperLog.info("PRE-scheduled async command: " + commandId + " in " + activePart + " Needs cleanup: " + needsCleanup);
+                    VrapperLog.debug("PRE-scheduled async command: " + commandId + " in " + activePart + " Needs cleanup: " + needsCleanup);
                 }
             });
         }
-    
+
         @Override
         public void notDefined(String commandId, NotDefinedException exception) {
             // TODO Auto-generated method stub
             IWorkbenchPart activePart = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart();
-            VrapperLog.info("Undefined command: " + commandId + " in " + activePart + ". Event: " + exception);
+            VrapperLog.debug("Undefined command: " + commandId + " in " + activePart + ". Event: " + exception);
             needsCleanup = false;
         }
-    
+
         @Override
         public void notEnabled(String commandId, NotEnabledException exception) {
             // TODO Auto-generated method stub
             IWorkbenchPart activePart = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart();
-            VrapperLog.info("Not enabled command: " + commandId + " in " + activePart + ". Exception: " + exception);
+            VrapperLog.debug("Not enabled command: " + commandId + " in " + activePart + ". Exception: " + exception);
             needsCleanup = false;
         }
-    
+
     }
 
     private static final class MouseButtonListener implements Listener {
-    	
+
     	private boolean down;
 
 		public void handleEvent(Event event) {

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperPlugin.java
@@ -383,6 +383,10 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
                 return;
             }
             IEditorPart activeEditor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+            if (activeEditor == null) {
+                // No editor active, e.g. on a fresh start.
+                return;
+            }
             InputInterceptor interceptor;
             try {
                 interceptor = VrapperPlugin.getDefault().findActiveInterceptor(activeEditor);
@@ -454,6 +458,10 @@ public class VrapperPlugin extends AbstractUIPlugin implements /*IStartup,*/ Log
             if (activeEditor == null) {
                 VrapperLog.info("No active editor info in event!");
                 activeEditor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+            }
+            if (activeEditor == null) {
+                // No editor active, e.g. on a fresh start.
+                return;
             }
             InputInterceptor interceptor;
             try {

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperStartup.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/activator/VrapperStartup.java
@@ -10,6 +10,7 @@ public class VrapperStartup implements IStartup {
         PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
             public void run() {
                 VrapperPlugin plugin = VrapperPlugin.plugin;
+                plugin.activateExtensions();
                 plugin.restoreVimEmulationInActiveEditors();
                 plugin.addEditorListeners();
                 plugin.addShutdownListener();

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
@@ -17,6 +17,7 @@ public class EclipseCommandHandler {
 
     protected EditorAdaptor editorAdaptor;
     protected Selection lastSelection;
+    protected boolean vrapperCommandActive;
 
     public EclipseCommandHandler(EditorAdaptor editorAdaptor) {
         this.editorAdaptor = editorAdaptor;
@@ -25,7 +26,7 @@ public class EclipseCommandHandler {
     public void beforeCommand(final String commandId) {
         // Always reset this
         lastSelection = null;
-        if ( ! VrapperPlugin.isVrapperEnabled()) {
+        if ( ! VrapperPlugin.isVrapperEnabled() || vrapperCommandActive) {
             return;
         }
         // [TODO] Eclipse motions don't know about inclusive mode; it's unable to change the
@@ -45,7 +46,7 @@ public class EclipseCommandHandler {
     }
 
     public void afterCommand(String commandId) {
-        if ( ! VrapperPlugin.isVrapperEnabled()) {
+        if ( ! VrapperPlugin.isVrapperEnabled() || vrapperCommandActive) {
             return;
         }
         // [TODO] Record that command was executed when recording a macro.
@@ -102,5 +103,13 @@ public class EclipseCommandHandler {
     }
 
     public void cleanup() {
+    }
+
+    public boolean isVrapperCommandActive() {
+        return vrapperCommandActive;
+    }
+
+    public void setVrapperCommandActive(boolean eclipseCommandActive) {
+        this.vrapperCommandActive = eclipseCommandActive;
     }
 }

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
@@ -49,6 +49,7 @@ public class EclipseCommandHandler {
     public void beforeCommand(final String commandId) {
         // Always reset this
         lastSelection = null;
+        recognizedCommandActive = false;
         if ( ! VrapperPlugin.isVrapperEnabled() || vrapperCommandActive) {
             return;
         }

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
@@ -1,0 +1,106 @@
+package net.sourceforge.vrapper.eclipse.interceptor;
+
+import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
+import net.sourceforge.vrapper.eclipse.commands.EclipseMotionPlugState;
+import net.sourceforge.vrapper.eclipse.commands.EclipseTextObjectPlugState;
+import net.sourceforge.vrapper.keymap.vim.PlugKeyStroke;
+import net.sourceforge.vrapper.log.VrapperLog;
+import net.sourceforge.vrapper.platform.SelectionService;
+import net.sourceforge.vrapper.utils.TextRange;
+import net.sourceforge.vrapper.vim.EditorAdaptor;
+import net.sourceforge.vrapper.vim.commands.Selection;
+import net.sourceforge.vrapper.vim.commands.SimpleSelection;
+import net.sourceforge.vrapper.vim.modes.AbstractVisualMode;
+import net.sourceforge.vrapper.vim.modes.commandline.AbstractCommandLineMode;
+
+public class EclipseCommandHandler {
+
+    protected EditorAdaptor editorAdaptor;
+    protected Selection lastSelection;
+
+    public EclipseCommandHandler(EditorAdaptor editorAdaptor) {
+        this.editorAdaptor = editorAdaptor;
+    }
+
+    public void beforeCommand(final String commandId) {
+        // Always reset this
+        lastSelection = null;
+        if ( ! VrapperPlugin.isVrapperEnabled()) {
+            return;
+        }
+        // [TODO] Eclipse motions don't know about inclusive mode; it's unable to change the
+        // selection to the left when Vrapper shows the cursor *on* a landing spot.
+        // Chop off that last character if selection is left-to-right and command is a motion.
+        TextRange selRange = editorAdaptor.getNativeSelection();
+        if (selRange.getModelLength() > 0 || selRange == SelectionService.VRAPPER_SELECTION_ACTIVE) {
+            if (selRange == SelectionService.VRAPPER_SELECTION_ACTIVE) {
+                // This is the generic part: store Vrapper selection so that 'gv' works.
+                editorAdaptor.rememberLastActiveSelection();
+                VrapperLog.debug("Stored Vrapper selection");
+            }
+            // Store current selection so that postExecuteSuccess can update it.
+            lastSelection = editorAdaptor.getSelection();
+            VrapperLog.debug("Grabbed selection");
+        }
+    }
+
+    public void afterCommand(String commandId) {
+        if ( ! VrapperPlugin.isVrapperEnabled()) {
+            return;
+        }
+        // [TODO] Record that command was executed when recording a macro.
+        if ("org.eclipse.jdt.ui.edit.text.java.select.enclosing".equals(commandId)
+                || "org.eclipse.jdt.ui.edit.text.java.select.last".equals(commandId)
+                || "org.eclipse.jdt.ui.edit.text.java.select.next".equals(commandId)
+                || "org.eclipse.jdt.ui.edit.text.java.select.previous".equals(commandId)
+                || "org.eclipse.ui.edit.selectAll".equals(commandId)
+                || "org.eclipse.ui.edit.text.moveLineUp".equals(commandId)
+                || "org.eclipse.ui.edit.text.moveLineDown".equals(commandId)
+                || "org.eclipse.ui.edit.text.select.wordPrevious".equals(commandId)
+                || "org.eclipse.ui.edit.text.select.wordNext".equals(commandId)
+            ) {
+            // Only works for Eclipse text objects, Eclipse motions need some different logic
+            TextRange nativeSelection = editorAdaptor.getNativeSelection();
+            // Vrapper selection might be still active if command did not modify selection state
+            if (nativeSelection.getModelLength() > 0
+                    && nativeSelection != SelectionService.VRAPPER_SELECTION_ACTIVE
+                    && ! (editorAdaptor.getCurrentMode() instanceof AbstractCommandLineMode)) {
+                // Record action plug in current macro
+                // [TODO] Don't do this when EclipseCommand is invoked from Vrapper
+                editorAdaptor.getMacroRecorder().handleKey(new PlugKeyStroke(EclipseTextObjectPlugState.TEXTOBJPREFIX + commandId + ')'));
+                if (lastSelection == null) {
+                    lastSelection = new SimpleSelection(nativeSelection);
+                }
+                lastSelection = lastSelection.wrap(editorAdaptor, nativeSelection);
+                editorAdaptor.setSelection(lastSelection);
+                // Should not pose any problems if we are still in the same visual mode.
+                editorAdaptor.changeModeSafely(lastSelection.getModeName(), AbstractVisualMode.KEEP_SELECTION_HINT);
+            }
+        } else if ("org.eclipse.ui.edit.text.goto.lineStart".equals(commandId)
+                || "org.eclipse.ui.edit.text.goto.lineEnd".equals(commandId)
+                || "org.eclipse.ui.edit.text.goto.wordPrevious".equals(commandId)
+                || "org.eclipse.ui.edit.text.goto.wordNext".equals(commandId)
+                || "org.eclipse.jdt.ui.edit.text.java.goto.matching.bracket".equals(commandId)
+                ) {
+            if (lastSelection != null) {
+                if (editorAdaptor.getCurrentMode() instanceof AbstractCommandLineMode) {
+                    // Restore selection to former state - Home / End will clear or mutilate sel
+                    // [TODO] Check for inclusive / exclusive!
+                    editorAdaptor.setSelection(lastSelection);
+                } else {
+                    // Record action plug in current macro
+                    // [TODO] Don't do this when EclipseCommand is invoked from Vrapper
+                    editorAdaptor.getMacroRecorder().handleKey(new PlugKeyStroke(EclipseMotionPlugState.MOTIONPREFIX + commandId + ')'));
+                    // [TODO] Check for inclusive / exclusive!
+                    lastSelection = lastSelection.reset(editorAdaptor, lastSelection.getFrom(), editorAdaptor.getPosition());
+                    editorAdaptor.setSelection(lastSelection);
+                    // Should not pose any problems if we are still in the same visual mode.
+                    editorAdaptor.changeModeSafely(lastSelection.getModeName(), AbstractVisualMode.KEEP_SELECTION_HINT);
+                }
+            }
+        }
+    }
+
+    public void cleanup() {
+    }
+}

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
@@ -107,7 +107,7 @@ public class EclipseCommandHandler {
                 if (lastSelection == null) {
                     lastSelection = new SimpleSelection(nativeSelection);
                 }
-                lastSelection = lastSelection.wrap(editorAdaptor, nativeSelection);
+                lastSelection = lastSelection.syncToTextRange(editorAdaptor, nativeSelection);
                 editorAdaptor.setSelection(lastSelection);
                 // Should not pose any problems if we are still in the same visual mode.
                 editorAdaptor.changeModeSafely(lastSelection.getModeName(), AbstractVisualMode.KEEP_SELECTION_HINT);

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
@@ -1,5 +1,8 @@
 package net.sourceforge.vrapper.eclipse.interceptor;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
 import net.sourceforge.vrapper.eclipse.commands.EclipseMotionPlugState;
 import net.sourceforge.vrapper.eclipse.commands.EclipseTextObjectPlugState;
@@ -18,9 +21,27 @@ public class EclipseCommandHandler {
     protected EditorAdaptor editorAdaptor;
     protected Selection lastSelection;
     protected boolean vrapperCommandActive;
+    protected Set<String> motions = new HashSet<String>();
+    protected Set<String> textObjects = new HashSet<String>();
 
     public EclipseCommandHandler(EditorAdaptor editorAdaptor) {
         this.editorAdaptor = editorAdaptor;
+
+        textObjects.add("org.eclipse.jdt.ui.edit.text.java.select.enclosing");
+        textObjects.add("org.eclipse.jdt.ui.edit.text.java.select.last");
+        textObjects.add("org.eclipse.jdt.ui.edit.text.java.select.next");
+        textObjects.add("org.eclipse.jdt.ui.edit.text.java.select.previous");
+        textObjects.add("org.eclipse.ui.edit.selectAll");
+        textObjects.add("org.eclipse.ui.edit.text.moveLineUp");
+        textObjects.add("org.eclipse.ui.edit.text.moveLineDown");
+        textObjects.add("org.eclipse.ui.edit.text.select.wordPrevious");
+        textObjects.add("org.eclipse.ui.edit.text.select.wordNext");
+
+        motions.add("org.eclipse.ui.edit.text.goto.lineStart");
+        motions.add("org.eclipse.ui.edit.text.goto.lineEnd");
+        motions.add("org.eclipse.ui.edit.text.goto.wordPrevious");
+        motions.add("org.eclipse.ui.edit.text.goto.wordNext");
+        motions.add("org.eclipse.jdt.ui.edit.text.java.goto.matching.bracket");
     }
 
     public void beforeCommand(final String commandId) {
@@ -49,17 +70,7 @@ public class EclipseCommandHandler {
         if ( ! VrapperPlugin.isVrapperEnabled() || vrapperCommandActive) {
             return;
         }
-        // [TODO] Record that command was executed when recording a macro.
-        if ("org.eclipse.jdt.ui.edit.text.java.select.enclosing".equals(commandId)
-                || "org.eclipse.jdt.ui.edit.text.java.select.last".equals(commandId)
-                || "org.eclipse.jdt.ui.edit.text.java.select.next".equals(commandId)
-                || "org.eclipse.jdt.ui.edit.text.java.select.previous".equals(commandId)
-                || "org.eclipse.ui.edit.selectAll".equals(commandId)
-                || "org.eclipse.ui.edit.text.moveLineUp".equals(commandId)
-                || "org.eclipse.ui.edit.text.moveLineDown".equals(commandId)
-                || "org.eclipse.ui.edit.text.select.wordPrevious".equals(commandId)
-                || "org.eclipse.ui.edit.text.select.wordNext".equals(commandId)
-            ) {
+        if (commandId != null && textObjects.contains(commandId)) {
             // Only works for Eclipse text objects, Eclipse motions need some different logic
             TextRange nativeSelection = editorAdaptor.getNativeSelection();
             // Vrapper selection might be still active if command did not modify selection state
@@ -77,12 +88,7 @@ public class EclipseCommandHandler {
                 // Should not pose any problems if we are still in the same visual mode.
                 editorAdaptor.changeModeSafely(lastSelection.getModeName(), AbstractVisualMode.KEEP_SELECTION_HINT);
             }
-        } else if ("org.eclipse.ui.edit.text.goto.lineStart".equals(commandId)
-                || "org.eclipse.ui.edit.text.goto.lineEnd".equals(commandId)
-                || "org.eclipse.ui.edit.text.goto.wordPrevious".equals(commandId)
-                || "org.eclipse.ui.edit.text.goto.wordNext".equals(commandId)
-                || "org.eclipse.jdt.ui.edit.text.java.goto.matching.bracket".equals(commandId)
-                ) {
+        } else if (commandId != null && motions.contains(commandId)) {
             if (lastSelection != null) {
                 if (editorAdaptor.getCurrentMode() instanceof AbstractCommandLineMode) {
                     // Restore selection to former state - Home / End will clear or mutilate sel

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandHandler.java
@@ -171,10 +171,23 @@ public class EclipseCommandHandler {
     public void cleanup() {
     }
 
-    public boolean isVrapperCommandActive() {
+    /**
+     * Returns whether the currently executing command is triggered through an Eclipse key or
+     * menu binding.
+     */
+    public boolean isEclipseTriggeredCommandActive() {
+        return recognizedCommandActive;
+    }
+
+    /**
+     * Returns whether Vrapper knows about a currently running Eclipse command. When true, the
+     * caller might want to skip certain cleanup steps lest it happen twice.
+     */
+    public boolean isCommandActive() {
         return vrapperCommandActive || recognizedCommandActive;
     }
 
+    /** Set whether a command is triggered by Vrapper through the ICommandService. */
     public void setVrapperCommandActive(boolean eclipseCommandActive) {
         this.vrapperCommandActive = eclipseCommandActive;
     }

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandRegistry.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/EclipseCommandRegistry.java
@@ -1,0 +1,76 @@
+package net.sourceforge.vrapper.eclipse.interceptor;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.Platform;
+
+import net.sourceforge.vrapper.log.VrapperLog;
+
+/**
+ * This singleton holds information about which Eclipse commands are interesting to listen for.
+ * Items can be pushed through special commandline instructions or through a Vrapper-specific
+ * extension point.
+ */
+public class EclipseCommandRegistry {
+    public static final EclipseCommandRegistry INSTANCE = new EclipseCommandRegistry();
+
+    protected EclipseCommandRegistry() {}
+
+    protected Set<String> motions = new CopyOnWriteArraySet<String>();
+    /**
+     * These motions should never leave the line.
+     * Note that they should still be added to {@link #motions}.
+     */
+    protected Set<String> noWrapMotions = new CopyOnWriteArraySet<String>();
+    protected Set<String> textObjects = new CopyOnWriteArraySet<String>();
+    protected Set<String> commands = new CopyOnWriteArraySet<String>();
+
+    public void addEclipseTextObject(String commandId) {
+        textObjects.add(commandId);
+    }
+
+    public void addEclipseMotion(String commandId, boolean restrictedToCurrentLine) {
+        motions.add(commandId);
+        if (restrictedToCurrentLine) {
+            noWrapMotions.add(commandId);
+        }
+    }
+
+    public void addEclipseCommand(String commandId) {
+        commands.add(commandId);
+    }
+
+    public void loadExtensionDeclarations() {
+        final IExtensionRegistry registry = Platform.getExtensionRegistry();
+        final IConfigurationElement[] elements = registry.getConfigurationElementsFor(
+                "net.sourceforge.vrapper.eclipse.commandregistry");
+
+        for (final IConfigurationElement element : elements) {
+            try {
+                if ("textobject".equals(element.getName())) {
+                    String command = element.getAttribute("command-id");
+                    if (command != null && command.trim().length() > 0) {
+                        addEclipseTextObject(command);
+                    }
+                } else if ("motion".equals(element.getName())) {
+                    String command = element.getAttribute("command-id");
+                    String restrictedToLineVal = element.getAttribute("restricted-to-line");
+                    boolean restrictedToLine = Boolean.parseBoolean(restrictedToLineVal);
+                    if (command != null && command.trim().length() > 0) {
+                        addEclipseMotion(command, restrictedToLine);
+                    }
+                } else if ("command".equals(element.getName())) {
+                    String command = element.getAttribute("command-id");
+                    if (command != null && command.trim().length() > 0) {
+                        addEclipseCommand(command);
+                    }
+                }
+            } catch (Exception e) {
+                VrapperLog.error("Failed to initialize eclipse command registry " + element, e);
+            }
+        }
+    }
+}

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptor.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/InputInterceptor.java
@@ -28,6 +28,9 @@ public interface InputInterceptor extends VerifyKeyListener {
     public CaretPositionUndoHandler getCaretPositionUndoHandler();
     public void setCaretPositionUndoHandler(CaretPositionUndoHandler handler);
 
+    public EclipseCommandHandler getEclipseCommandHandler();
+    public void setEclipseCommandHandler(EclipseCommandHandler handler);
+
     public EclipsePlatform getPlatform();
     public void setPlatform(EclipsePlatform platform);
 }

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/LinkedModeHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/LinkedModeHandler.java
@@ -5,6 +5,7 @@ import net.sourceforge.vrapper.vim.EditorAdaptor;
 import net.sourceforge.vrapper.vim.modes.ContentAssistMode;
 import net.sourceforge.vrapper.vim.modes.InsertMode;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
+import net.sourceforge.vrapper.vim.modes.SelectMode;
 
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
@@ -49,6 +50,7 @@ public class LinkedModeHandler implements IDocumentListener, ILinkedModeListener
             String mode = hintReceiver.getCurrentModeName();
             if (VrapperPlugin.isVrapperEnabled()
                     && ! InsertMode.NAME.equals(mode)
+                    && ! SelectMode.NAME.equals(mode)
                     && ! ContentAssistMode.NAME.equals(mode)
                     && ! NormalMode.NAME.equals(mode)) {
                 hintReceiver.changeModeSafely(NormalMode.NAME);

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
@@ -78,7 +78,7 @@ public class SelectionVisualHandler implements ISelectionChangedListener {
                 commandMode.placeCursor(StickyColumnPolicy.RESET_EOL);
             }
         } else if ( ! (VrapperPlugin.isMouseDown() && config.get(Options.VISUAL_MOUSE))
-                && ! config.get(Options.VISUAL_OTHER)) {
+                && ! ( ! VrapperPlugin.isMouseDown() && config.get(Options.VISUAL_OTHER))) {
             // Mark selection as "conflicted" - we're in Normal mode but somehow a selection exists
             if (editorAdaptor.getCurrentMode() instanceof NormalMode) {
                 ((CommandBasedMode)editorAdaptor.getCurrentMode()).placeCursor(StickyColumnPolicy.NEVER);

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
@@ -28,19 +28,22 @@ public class SelectionVisualHandler implements ISelectionChangedListener {
 
     private DefaultEditorAdaptor editorAdaptor;
     private EclipseCursorAndSelection selectionService;
+    private EclipseCommandHandler commandHandler;
     private ITextViewer textViewer;
     private int selectionResetOffset = -1;
 
     public SelectionVisualHandler(DefaultEditorAdaptor editorAdaptor,
-            EclipseCursorAndSelection selectionService, ITextViewer viewer) {
+            EclipseCursorAndSelection selectionService, ITextViewer viewer,
+            EclipseCommandHandler commandHandler) {
         this.editorAdaptor = editorAdaptor;
         this.textViewer = viewer;
         this.selectionService = selectionService;
+        this.commandHandler = commandHandler;
     }
 
     public void selectionChanged(SelectionChangedEvent event) {
         if (!VrapperPlugin.isVrapperEnabled() || !(event.getSelection() instanceof TextSelection)
-                || selectionService.isSelectionInProgress()) {
+                || selectionService.isSelectionInProgress() || commandHandler.isVrapperCommandActive()) {
             return;
         }
 

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
@@ -19,6 +19,7 @@ import net.sourceforge.vrapper.vim.modes.CommandBasedMode;
 import net.sourceforge.vrapper.vim.modes.EditorMode;
 import net.sourceforge.vrapper.vim.modes.InsertMode;
 import net.sourceforge.vrapper.vim.modes.NormalMode;
+import net.sourceforge.vrapper.vim.modes.SelectMode;
 import net.sourceforge.vrapper.vim.modes.TempVisualMode;
 import net.sourceforge.vrapper.vim.modes.TemporaryMode;
 import net.sourceforge.vrapper.vim.modes.VisualMode;
@@ -66,6 +67,9 @@ public class SelectionVisualHandler implements ISelectionChangedListener {
             // User cleared selection or moved caret with mouse in a temporary mode.
             if(currentMode instanceof TemporaryMode) {
                 editorAdaptor.changeModeSafely(InsertMode.NAME);
+            // Selection cleared, most likely some Eclipse motion ( e.g. Home / End )
+            } else if(currentMode instanceof SelectMode) {
+                editorAdaptor.changeModeSafely(InsertMode.NAME, InsertMode.DONT_MOVE_CURSOR);
             } else if(currentMode instanceof AbstractVisualMode){
                 editorAdaptor.changeModeSafely(NormalMode.NAME);
             // Cursor can be after the line if an Eclipse operation cleared the selection, e.g. undo
@@ -90,8 +94,14 @@ public class SelectionVisualHandler implements ISelectionChangedListener {
                 editorAdaptor.changeModeSafely(VisualMode.NAME, AbstractVisualMode.KEEP_SELECTION_HINT);
             }
             else if (InsertMode.NAME.equals(editorAdaptor.getCurrentModeName())) {
-                editorAdaptor.changeModeSafely(TempVisualMode.NAME,
-                        AbstractVisualMode.KEEP_SELECTION_HINT, InsertMode.DONT_MOVE_CURSOR);
+                // [TODO] Make configurable
+                if (VrapperPlugin.isMouseDown()) {
+                    editorAdaptor.changeModeSafely(TempVisualMode.NAME,
+                            AbstractVisualMode.KEEP_SELECTION_HINT, InsertMode.DONT_MOVE_CURSOR);
+                } else {
+                    editorAdaptor.changeModeSafely(SelectMode.NAME,
+                            AbstractVisualMode.KEEP_SELECTION_HINT, InsertMode.DONT_MOVE_CURSOR);
+                }
             }
             // Store the selection - user might click with mouse and immediately destroy selection
             editorAdaptor.rememberLastActiveSelection();

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
@@ -11,6 +11,7 @@ import net.sourceforge.vrapper.eclipse.activator.VrapperPlugin;
 import net.sourceforge.vrapper.eclipse.platform.EclipseCursorAndSelection;
 import net.sourceforge.vrapper.log.VrapperLog;
 import net.sourceforge.vrapper.vim.DefaultEditorAdaptor;
+import net.sourceforge.vrapper.vim.LocalConfiguration;
 import net.sourceforge.vrapper.vim.Options;
 import net.sourceforge.vrapper.vim.commands.motions.StickyColumnPolicy;
 import net.sourceforge.vrapper.vim.modes.AbstractVisualMode;
@@ -43,6 +44,7 @@ public class SelectionVisualHandler implements ISelectionChangedListener {
         }
 
         TextSelection selection = (TextSelection) event.getSelection();
+        LocalConfiguration config = editorAdaptor.getConfiguration();
         // selection.isEmpty() is false even if length == 0, don't use it
         if (selection.getLength() == 0) {
             // Explicitly reset selection. EclipseCursorAndSelection's SelectionChangeListener is
@@ -71,8 +73,8 @@ public class SelectionVisualHandler implements ISelectionChangedListener {
                 CommandBasedMode commandMode = (CommandBasedMode) currentMode;
                 commandMode.placeCursor(StickyColumnPolicy.RESET_EOL);
             }
-        } else if ( ! VrapperPlugin.isMouseDown()
-                || !editorAdaptor.getConfiguration().get(Options.VISUAL_MOUSE)) {
+        } else if ( ! (VrapperPlugin.isMouseDown() && config.get(Options.VISUAL_MOUSE))
+                && ! config.get(Options.VISUAL_OTHER)) {
             // Mark selection as "conflicted" - we're in Normal mode but somehow a selection exists
             if (editorAdaptor.getCurrentMode() instanceof NormalMode) {
                 ((CommandBasedMode)editorAdaptor.getCurrentMode()).placeCursor(StickyColumnPolicy.NEVER);

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/SelectionVisualHandler.java
@@ -43,7 +43,7 @@ public class SelectionVisualHandler implements ISelectionChangedListener {
 
     public void selectionChanged(SelectionChangedEvent event) {
         if (!VrapperPlugin.isVrapperEnabled() || !(event.getSelection() instanceof TextSelection)
-                || selectionService.isSelectionInProgress() || commandHandler.isVrapperCommandActive()) {
+                || selectionService.isSelectionInProgress() || commandHandler.isCommandActive()) {
             return;
         }
 

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
@@ -281,6 +281,8 @@ public class VimInputInterceptorFactory implements InputInterceptorFactory {
             }
         }
 
+        interceptor.setEclipseCommandHandler(new EclipseCommandHandler(editorAdaptor));
+
         SelectionVisualHandler visualHandler = new SelectionVisualHandler(editorAdaptor,
                 platform.getSelectionService(), textViewer);
         interceptor.setSelectionVisualHandler(visualHandler);
@@ -299,6 +301,7 @@ public class VimInputInterceptorFactory implements InputInterceptorFactory {
         private CaretPositionHandler caretPositionHandler;
         private SelectionVisualHandler selectionVisualHandler;
         private CaretPositionUndoHandler caretPositionUndoHandler;
+        private EclipseCommandHandler eclipseCommandHandler;
         private EclipsePlatform eclipsePlatform;
 
         private VimInputInterceptor(EditorAdaptor editorAdaptor) {
@@ -406,6 +409,16 @@ public class VimInputInterceptorFactory implements InputInterceptorFactory {
         @Override
         public void setCaretPositionUndoHandler(CaretPositionUndoHandler handler) {
             this.caretPositionUndoHandler = handler;
+        }
+
+        @Override
+        public EclipseCommandHandler getEclipseCommandHandler() {
+            return eclipseCommandHandler;
+        }
+
+        @Override
+        public void setEclipseCommandHandler(EclipseCommandHandler handler) {
+            this.eclipseCommandHandler = handler;
         }
 
         @Override

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
@@ -260,6 +260,7 @@ public class VimInputInterceptorFactory implements InputInterceptorFactory {
         InputInterceptor interceptor = createInterceptor(editorAdaptor);
         interceptor.setPlatform(platform);
         interceptor.setEditorInfo(partInfo);
+        platform.getServiceProvider().setInputInterceptor(interceptor);
 
         interceptor.setCaretPositionUndoHandler(new CaretPositionUndoHandler(editorAdaptor, textViewer));
         editorAdaptor.addVrapperEventListener(interceptor.getCaretPositionUndoHandler());

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
@@ -282,7 +282,8 @@ public class VimInputInterceptorFactory implements InputInterceptorFactory {
             }
         }
 
-        interceptor.setEclipseCommandHandler(new EclipseCommandHandler(editorAdaptor));
+        interceptor.setEclipseCommandHandler(new EclipseCommandHandler(editorAdaptor,
+                EclipseCommandRegistry.INSTANCE));
 
         SelectionVisualHandler visualHandler = new SelectionVisualHandler(editorAdaptor,
                 platform.getSelectionService(), textViewer, interceptor.getEclipseCommandHandler());

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/interceptor/VimInputInterceptorFactory.java
@@ -285,7 +285,7 @@ public class VimInputInterceptorFactory implements InputInterceptorFactory {
         interceptor.setEclipseCommandHandler(new EclipseCommandHandler(editorAdaptor));
 
         SelectionVisualHandler visualHandler = new SelectionVisualHandler(editorAdaptor,
-                platform.getSelectionService(), textViewer);
+                platform.getSelectionService(), textViewer, interceptor.getEclipseCommandHandler());
         interceptor.setSelectionVisualHandler(visualHandler);
         return interceptor;
     }

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -19,6 +19,7 @@ import org.eclipse.jface.text.BadPositionCategoryException;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.ITextViewerExtension5;
+import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -514,7 +515,8 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void widgetSelected(final SelectionEvent arg0) {
-            VrapperLog.debug("Detected selection change; suppressed = " + selectionInProgress);
+            VrapperLog.debug("Detected selection change; suppressed = " + selectionInProgress +
+                    ", details: " + textViewer.getTextWidget().getSelection());
             if ( ! selectionInProgress) {
                 selection = null;
                 // getPosition() compensates for inclusive visual selection's caret offset.
@@ -531,7 +533,10 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void selectionChanged(SelectionChangedEvent event) {
-            VrapperLog.debug("Detected jface selection change; suppressed = " + selectionInProgress);
+            TextSelection textSelection = (TextSelection)event.getSelection();
+            VrapperLog.debug("Detected jface selection change; suppressed = " + selectionInProgress
+                    + ", details: " + textSelection.getOffset() + "," + textSelection.getLength()
+                    + " type: " + textSelection.getClass());
             if ( ! selectionInProgress) {
                 selection = null;
                 // getPosition() compensates for inclusive visual selection's caret offset.

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -319,6 +319,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
     @Override
     public void setSelection(final Selection newSel) {
+        VrapperLog.debug("Updated selection " + newSel);
         selectionInProgress = true;
         selection = newSel;
         ContentType contentType = newSel == null ? null: newSel.getContentType(configuration);

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import net.sourceforge.vrapper.utils.TextRange;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -286,7 +287,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
         }
         return new SimpleSelection(from, to, range);
     }
-    
+
     @Override
     public TextRange getNativeSelection() {
         if (selection != null) {
@@ -513,6 +514,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void widgetSelected(final SelectionEvent arg0) {
+            VrapperLog.info("Detected selection change; suppressed = " + selectionInProgress);
             if ( ! selectionInProgress) {
                 selection = null;
                 // getPosition() compensates for inclusive visual selection's caret offset.
@@ -529,6 +531,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void selectionChanged(SelectionChangedEvent event) {
+            VrapperLog.info("Detected jface selection change; suppressed = " + selectionInProgress);
             if ( ! selectionInProgress) {
                 selection = null;
                 // getPosition() compensates for inclusive visual selection's caret offset.

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseCursorAndSelection.java
@@ -514,7 +514,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void widgetSelected(final SelectionEvent arg0) {
-            VrapperLog.info("Detected selection change; suppressed = " + selectionInProgress);
+            VrapperLog.debug("Detected selection change; suppressed = " + selectionInProgress);
             if ( ! selectionInProgress) {
                 selection = null;
                 // getPosition() compensates for inclusive visual selection's caret offset.
@@ -531,7 +531,7 @@ public class EclipseCursorAndSelection implements CursorService, SelectionServic
 
         @Override
         public void selectionChanged(SelectionChangedEvent event) {
-            VrapperLog.info("Detected jface selection change; suppressed = " + selectionInProgress);
+            VrapperLog.debug("Detected jface selection change; suppressed = " + selectionInProgress);
             if ( ! selectionInProgress) {
                 selection = null;
                 // getPosition() compensates for inclusive visual selection's caret offset.

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipsePlatform.java
@@ -25,7 +25,6 @@ import net.sourceforge.vrapper.platform.PlatformSpecificModeProvider;
 import net.sourceforge.vrapper.platform.PlatformSpecificStateProvider;
 import net.sourceforge.vrapper.platform.PlatformSpecificTextObjectProvider;
 import net.sourceforge.vrapper.platform.SearchAndReplaceService;
-import net.sourceforge.vrapper.platform.ServiceProvider;
 import net.sourceforge.vrapper.platform.TextContent;
 import net.sourceforge.vrapper.platform.UnderlyingEditorSettings;
 import net.sourceforge.vrapper.platform.UserInterfaceService;
@@ -153,7 +152,7 @@ public class EclipsePlatform implements Platform {
     }
 
     @Override
-    public ServiceProvider getServiceProvider() {
+    public EclipseServiceProvider getServiceProvider() {
         return serviceProvider;
     }
 

--- a/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseServiceProvider.java
+++ b/plugins/net.sourceforge.vrapper.eclipse/src/net/sourceforge/vrapper/eclipse/platform/EclipseServiceProvider.java
@@ -1,6 +1,9 @@
 package net.sourceforge.vrapper.eclipse.platform;
 
+import net.sourceforge.vrapper.eclipse.interceptor.EclipseCommandHandler;
+import net.sourceforge.vrapper.eclipse.interceptor.InputInterceptor;
 import net.sourceforge.vrapper.platform.ServiceProvider;
+import net.sourceforge.vrapper.platform.VrapperPlatformException;
 
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
@@ -10,21 +13,38 @@ public class EclipseServiceProvider implements ServiceProvider {
 
     private final IHandlerService handlerService;
     private final ICommandService commandService;
+    private InputInterceptor interceptor;
 
     public EclipseServiceProvider(AbstractTextEditor abstractTextEditor) {
         handlerService = (IHandlerService) abstractTextEditor.getSite().getService(IHandlerService.class);
         commandService = (ICommandService) abstractTextEditor.getSite().getService(ICommandService.class);
     }
+    
+    public void setInputInterceptor(InputInterceptor interceptor) {
+        this.interceptor = interceptor;
+    }
 
     @SuppressWarnings("unchecked")
     public <T> T getService(Class<T> serviceClass) {
         if (IHandlerService.class.equals(serviceClass)) {
+            guardService("IHandlerService", handlerService);
             return (T) handlerService;
         }
         if (ICommandService.class.equals(serviceClass)) {
+            guardService("ICommandService", commandService);
             return (T) commandService;
+        }
+        if (EclipseCommandHandler.class.equals(serviceClass)) {
+            guardService("InputInterceptor", interceptor);
+            guardService("EclipseCommandHandler", interceptor.getEclipseCommandHandler());
+            return (T) interceptor.getEclipseCommandHandler();
         }
         return null;
     }
 
+    protected void guardService(String svcDescription, Object service) {
+        if (service == null) {
+            throw new VrapperPlatformException(svcDescription + " service was not found");
+        }
+    }
 }

--- a/tests/net.sourceforge.vrapper.testutil/src/net/sourceforge/vrapper/testutil/TestCursorAndSelection.java
+++ b/tests/net.sourceforge.vrapper.testutil/src/net/sourceforge/vrapper/testutil/TestCursorAndSelection.java
@@ -147,7 +147,7 @@ public class TestCursorAndSelection implements CursorService, SelectionService {
 		nativeSelection = range;
 	}
 
-	public void setSelection(Selection selection) {
+    public void setSelection(Selection selection) {
 		if (selection != null)
 			this.position = selection.getEnd();
 		this.selection = selection;


### PR DESCRIPTION
Detects a selection or movements based on Eclipse commands.

This way one could make Eclipse commands repeatable, record them in macros, or just use it to keep the selection in sync.

Note that any Eclipse command which is not registered will simply use the classic "selection conflict" mode where the caret is a small thin line near the top of the line.